### PR TITLE
feat: フロントエンド GitHub OAuth 連携実装（issue #8）

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,13 +2,14 @@ import { Routes, Route } from 'react-router-dom'
 import Login from './pages/Login'
 import Home from './pages/Home'
 import Analysis from './pages/Analysis'
+import { RequireAuth } from './components/auth/RequireAuth'
 
 export default function App() {
   return (
     <Routes>
       <Route path="/login" element={<Login />} />
-      <Route path="/" element={<Home />} />
-      <Route path="/analysis/:jobId" element={<Analysis />} />
+      <Route path="/" element={<RequireAuth><Home /></RequireAuth>} />
+      <Route path="/analysis/:jobId" element={<RequireAuth><Analysis /></RequireAuth>} />
     </Routes>
   )
 }

--- a/frontend/src/components/auth/RequireAuth.tsx
+++ b/frontend/src/components/auth/RequireAuth.tsx
@@ -1,0 +1,13 @@
+import { Navigate, useLocation } from 'react-router-dom'
+import { useAuth } from '@/hooks/useAuth'
+
+export function RequireAuth({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated, isLoading } = useAuth()
+  const location = useLocation()
+
+  if (isLoading) return <div className="p-8 text-muted-foreground">読み込み中…</div>
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace state={{ from: location.pathname }} />
+  }
+  return <>{children}</>
+}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,4 +1,24 @@
-// TODO: ログインユーザー情報・ログアウトボタン
+import { Button } from '@/components/ui/button'
+import { useAuth, useLogout } from '@/hooks/useAuth'
+
 export default function Header() {
-  return <header>Header</header>;
+  const { user } = useAuth()
+  const logout = useLogout()
+
+  return (
+    <header className="flex h-14 items-center justify-between border-b px-6">
+      <span className="font-semibold">ReviewArena</span>
+      <div className="flex items-center gap-3">
+        {user && <span className="text-sm text-muted-foreground">{user.login}</span>}
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => logout.mutate()}
+          disabled={logout.isPending}
+        >
+          ログアウト
+        </Button>
+      </div>
+    </header>
+  )
 }

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,1 +1,38 @@
-// TODO: 認証状態の取得・ログアウト操作
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { ApiError, apiFetch, apiFetchVoid } from '@/lib/api'
+
+type Me = { login: string }
+
+export function useAuth() {
+  const query = useQuery<Me | null>({
+    queryKey: ['auth', 'me'],
+    queryFn: async () => {
+      try {
+        return await apiFetch<Me>('/auth/me')
+      } catch (e) {
+        if (e instanceof ApiError && e.status === 401) return null
+        throw e
+      }
+    },
+    staleTime: Infinity,
+    retry: false,
+  })
+  return {
+    user: query.data ?? null,
+    isLoading: query.isLoading,
+    isAuthenticated: !!query.data,
+  }
+}
+
+export function useLogout() {
+  const qc = useQueryClient()
+  const navigate = useNavigate()
+  return useMutation({
+    mutationFn: () => apiFetchVoid('/auth/logout', { method: 'POST' }),
+    onSuccess: () => {
+      qc.setQueryData(['auth', 'me'], null)
+      navigate('/login', { replace: true })
+    },
+  })
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,1 +1,30 @@
-// TODO: fetch ラッパー・/api/* への共通リクエスト・エラーハンドリング
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'ApiError'
+  }
+}
+
+export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(path, {
+    ...init,
+    headers: { Accept: 'application/json', ...init?.headers },
+  })
+  if (!res.ok) {
+    throw new ApiError(res.status, `${res.status} ${res.statusText}`)
+  }
+  return res.json() as Promise<T>
+}
+
+export async function apiFetchVoid(path: string, init?: RequestInit): Promise<void> {
+  const res = await fetch(path, {
+    ...init,
+    headers: { Accept: 'application/json', ...init?.headers },
+  })
+  if (!res.ok) {
+    throw new ApiError(res.status, `${res.status} ${res.statusText}`)
+  }
+}

--- a/frontend/src/lib/queryClient.ts
+++ b/frontend/src/lib/queryClient.ts
@@ -1,1 +1,15 @@
-// TODO: TanStack QueryClient のシングルトン設定（staleTime・retry ポリシー）
+import { QueryClient } from '@tanstack/react-query'
+import { ApiError } from './api'
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      retry: (failureCount, error) => {
+        if (error instanceof ApiError && error.status >= 400 && error.status < 500) return false
+        return failureCount < 2
+      },
+      refetchOnWindowFocus: false,
+    },
+  },
+})

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,17 +1,17 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
-// TODO: import { QueryClientProvider } from '@tanstack/react-query'
-// TODO: import { queryClient } from './lib/queryClient'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { queryClient } from './lib/queryClient'
 import './index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
-      {/* TODO: <QueryClientProvider client={queryClient}> */}
-      <App />
-      {/* TODO: </QueryClientProvider> */}
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
     </BrowserRouter>
   </StrictMode>,
 )

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,11 +1,15 @@
 import { Button } from "@/components/ui/button"
+import Header from "@/components/layout/Header"
 
 // TODO: PR URL 入力フォーム・解析リクエスト送信
 export default function Home() {
   return (
-    <div className="p-8 space-y-4">
-      <h1 className="text-2xl font-bold">ReviewArena</h1>
-      <Button>動作確認</Button>
+    <div>
+      <Header />
+      <main className="p-8 space-y-4">
+        <h1 className="text-2xl font-bold">ReviewArena</h1>
+        <Button>動作確認</Button>
+      </main>
     </div>
   );
 }

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,4 +1,29 @@
-// TODO: GitHub OAuth ボタン・未認証時のランディングページ
+import { Navigate, useLocation } from 'react-router-dom'
+import { buttonVariants } from '@/components/ui/button'
+import { useAuth } from '@/hooks/useAuth'
+
 export default function Login() {
-  return <div>Login</div>;
+  const { isAuthenticated, isLoading } = useAuth()
+  const location = useLocation()
+  const from = (location.state as { from?: string } | null)?.from ?? '/'
+
+  if (isLoading) return <div className="p-8 text-muted-foreground">読み込み中…</div>
+  if (isAuthenticated) return <Navigate to={from} replace />
+
+  return (
+    <div className="flex min-h-svh items-center justify-center">
+      <div className="w-full max-w-sm space-y-6 rounded-xl border bg-card p-8 shadow-sm">
+        <div className="space-y-1 text-center">
+          <h1 className="text-2xl font-bold">ReviewArena</h1>
+          <p className="text-sm text-muted-foreground">ログインして PR 依存グラフを可視化</p>
+        </div>
+        <a
+          href="/auth/github"
+          className={buttonVariants({ variant: 'default', size: 'lg' }) + ' w-full justify-center'}
+        >
+          GitHub でログイン
+        </a>
+      </div>
+    </div>
+  )
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,6 +5,7 @@
     { "path": "./tsconfig.node.json" }
   ],
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
## Summary

- `lib/api.ts`: `ApiError` / `apiFetch` / `apiFetchVoid` を実装。同一オリジン fetch ラッパー
- `lib/queryClient.ts`: TanStack QueryClient を staleTime・retry ポリシー付きで初期化
- `hooks/useAuth.ts`: `/auth/me` を `staleTime: Infinity` で管理する `useAuth`・ログアウト後に queryData を即時 null 上書きする `useLogout`
- `components/auth/RequireAuth.tsx`: 未認証時に `/login` へリダイレクトするルートガード
- `pages/Login.tsx`: 未認証時に GitHub OAuth ボタン表示、認証済みなら `from` パスへリダイレクト
- `components/layout/Header.tsx`: ログインユーザー名とログアウトボタン
- `App.tsx`: `/` と `/analysis/:jobId` を `<RequireAuth>` でガード
- `pages/Home.tsx`: 先頭に `<Header />` を組み込み
- `tsconfig.json`: `ignoreDeprecations: "6.0"` 追加（`baseUrl` 非推奨警告を解消）

## Test plan

- [x] `docker compose up -d` で起動
- [x] `http://localhost/` にアクセス → `/login` にリダイレクトされる
- [x] `GitHub でログイン` 押下 → GitHub 認可画面 → `/` に戻りヘッダーに GitHub ログイン名が表示される
- [x] リロード後も `/` のまま（セッション継続）
- [x] `ログアウト` 押下 → `/login` にリダイレクト、`/` を直叩きしても `/login` に戻される
- [x] DevTools Cookies で `sid` が HttpOnly・7日有効なことを確認
- [x] `tsc --noEmit` がエラーなしで通る

closes #8