### PR TITLE
feat: REST API エンドポイント実装 (issue #7)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -1,12 +1,24 @@
 package main
 
 import (
+	"context"
 	"log"
+	"net/http"
 	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/s-sh1m0/u-22_procon/backend/internal/api"
-	"github.com/s-sh1m0/u-22_procon/backend/internal/infra/github"
+	"github.com/s-sh1m0/u-22_procon/backend/internal/infra/analyzer"
+	"github.com/s-sh1m0/u-22_procon/backend/internal/infra/cluster"
+	githubinfra "github.com/s-sh1m0/u-22_procon/backend/internal/infra/github"
+	"github.com/s-sh1m0/u-22_procon/backend/internal/infra/job"
 	"github.com/s-sh1m0/u-22_procon/backend/internal/infra/store"
+	"github.com/s-sh1m0/u-22_procon/backend/internal/usecase"
 )
 
 func main() {
@@ -28,11 +40,57 @@ func main() {
 		log.Fatalf("init session repo: %v", err)
 	}
 
-	oauth := github.NewOAuthConfig(clientID, clientSecret, callbackURL)
-	authHandler := api.NewAuthHandler(oauth, sessions)
-	router := api.NewRouter(authHandler, sessions)
+	analysisRepo := store.NewAnalysisRepo(db)
+	jobRepo := store.NewJobRepo(db)
 
-	router.Logger.Fatal(router.Start(":" + port))
+	prRepo := githubinfra.NewPRRepo()
+	sourceTree := analyzer.NewSourceTree(analyzer.NewGitCloner(), analyzer.NewGoPackageLoader())
+	cgBuilder := analyzer.NewGoCallGraphBuilder()
+	clusterer := cluster.NewLouvainClusterer()
+
+	queueBuf := envIntOr("JOB_QUEUE_BUFFER", 32)
+	queue := job.NewQueue(queueBuf)
+	worker := job.NewWorker(queue, jobRepo, analysisRepo, prRepo, sourceTree, cgBuilder, clusterer)
+
+	analyzeUC := usecase.NewAnalyzePRUseCase(analysisRepo, jobRepo, queue)
+	getUC := usecase.NewGetAnalysisUseCase(analysisRepo, jobRepo)
+
+	oauth := githubinfra.NewOAuthConfig(clientID, clientSecret, callbackURL)
+	authHandler := api.NewAuthHandler(oauth, sessions)
+	analysisHandler := api.NewAnalysisHandler(analyzeUC, getUC)
+	jobHandler := api.NewJobHandler(getUC)
+	router := api.NewRouter(authHandler, analysisHandler, jobHandler, sessions)
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	eg, egCtx := errgroup.WithContext(ctx)
+
+	eg.Go(func() error {
+		return worker.Run(egCtx)
+	})
+
+	eg.Go(func() error {
+		if err := router.Start(":" + port); err != nil && err != http.ErrServerClosed {
+			return err
+		}
+		return nil
+	})
+
+	eg.Go(func() error {
+		<-egCtx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := router.Shutdown(shutdownCtx); err != nil {
+			log.Printf("server shutdown: %v", err)
+		}
+		queue.Close()
+		return nil
+	})
+
+	if err := eg.Wait(); err != nil && err != context.Canceled {
+		log.Fatalf("server error: %v", err)
+	}
 }
 
 func mustEnv(key string) string {
@@ -46,6 +104,15 @@ func mustEnv(key string) string {
 func envOr(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {
 		return v
+	}
+	return fallback
+}
+
+func envIntOr(key string, fallback int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
 	}
 	return fallback
 }

--- a/backend/internal/api/analysis_handler.go
+++ b/backend/internal/api/analysis_handler.go
@@ -1,3 +1,132 @@
 package api
 
-// TODO: POST /api/analyses, GET /api/analyses/:id
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
+	"github.com/s-sh1m0/u-22_procon/backend/internal/usecase"
+)
+
+// analyzeUseCase は AnalysisHandler が使うユースケースインターフェース。
+type analyzeUseCase interface {
+	Execute(ctx context.Context, token string, pr domain.PRInfo) (domain.JobID, error)
+}
+
+// readUseCase は AnalysisHandler と JobHandler が使うユースケースインターフェース。
+type readUseCase interface {
+	GetJob(ctx context.Context, id domain.JobID) (*domain.Job, error)
+	GetGraph(ctx context.Context, id domain.JobID) (*domain.Analysis, error)
+}
+
+// AnalysisHandler は /api/analyze と /api/graph/:jobId のハンドラ。
+type AnalysisHandler struct {
+	analyze analyzeUseCase
+	read    readUseCase
+}
+
+// NewAnalysisHandler は AnalysisHandler を返す。
+func NewAnalysisHandler(analyze analyzeUseCase, read readUseCase) *AnalysisHandler {
+	return &AnalysisHandler{analyze: analyze, read: read}
+}
+
+// Analyze は POST /api/analyze を処理する。
+func (h *AnalysisHandler) Analyze(c echo.Context) error {
+	var req AnalyzeRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+	}
+	if req.PRURL == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "pr_url is required")
+	}
+
+	pr, err := parsePRURL(req.PRURL)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+
+	sess, ok := c.Get(contextKeySession).(*domain.Session)
+	if !ok || sess == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized)
+	}
+
+	ctx := c.Request().Context()
+	jobID, err := h.analyze.Execute(ctx, sess.GitHubToken, *pr)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("start analysis: %v", err))
+	}
+
+	j, err := h.read.GetJob(ctx, jobID)
+	if err != nil || j == nil {
+		return c.JSON(http.StatusOK, JobResponse{JobID: string(jobID), Status: "pending"})
+	}
+	return c.JSON(http.StatusOK, JobResponse{
+		JobID:      string(j.ID),
+		Status:     string(j.Status),
+		AnalysisID: string(j.AnalysisID),
+		Error:      j.Error,
+	})
+}
+
+// GetGraph は GET /api/graph/:jobId を処理する。
+func (h *AnalysisHandler) GetGraph(c echo.Context) error {
+	id := c.Param("jobId")
+	if id == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "jobId is required")
+	}
+
+	analysis, err := h.read.GetGraph(c.Request().Context(), domain.JobID(id))
+	if err != nil {
+		if errors.Is(err, usecase.ErrJobNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "job not found")
+		}
+		if errors.Is(err, usecase.ErrJobNotReady) {
+			return echo.NewHTTPError(http.StatusConflict, "job not ready")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("get graph: %v", err))
+	}
+
+	return c.JSON(http.StatusOK, toGraphResponse(analysis.Result))
+}
+
+// parsePRURL は GitHub PR の URL をパースして PRInfo を返す。
+// 受け入れる形式: https://github.com/{owner}/{repo}/pull/{number}
+func parsePRURL(rawURL string) (*domain.PRInfo, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return nil, fmt.Errorf("URL scheme must be http or https, got %q", u.Scheme)
+	}
+	if u.Host != "github.com" {
+		return nil, fmt.Errorf("URL host must be github.com, got %q", u.Host)
+	}
+
+	// path: /owner/repo/pull/number
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) != 4 {
+		return nil, fmt.Errorf("URL path must be /owner/repo/pull/number, got %q", u.Path)
+	}
+	owner, repo, pullLiteral, numberStr := parts[0], parts[1], parts[2], parts[3]
+	if owner == "" || repo == "" {
+		return nil, fmt.Errorf("owner and repo must not be empty")
+	}
+	if pullLiteral != "pull" {
+		return nil, fmt.Errorf("URL must contain /pull/, got %q", pullLiteral)
+	}
+
+	number, err := strconv.Atoi(numberStr)
+	if err != nil || number <= 0 {
+		return nil, fmt.Errorf("PR number must be a positive integer, got %q", numberStr)
+	}
+
+	return &domain.PRInfo{Owner: owner, Repo: repo, Number: number}, nil
+}

--- a/backend/internal/api/analysis_handler_test.go
+++ b/backend/internal/api/analysis_handler_test.go
@@ -43,17 +43,6 @@ func (f *fakeReadUC) GetGraph(_ context.Context, _ domain.JobID) (*domain.Analys
 
 // --- helpers ---
 
-func newEchoWithSession(sess *domain.Session) (*echo.Echo, echo.Context, *httptest.ResponseRecorder) {
-	e := echo.New()
-	req := httptest.NewRequest(http.MethodPost, "/api/analyze", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	if sess != nil {
-		c.Set(contextKeySession, sess)
-	}
-	return e, c, rec
-}
-
 func validSession() *domain.Session {
 	return &domain.Session{ID: "sid", GitHubToken: "ghtok", UserLogin: "user", CreatedAt: time.Now()}
 }

--- a/backend/internal/api/analysis_handler_test.go
+++ b/backend/internal/api/analysis_handler_test.go
@@ -1,0 +1,247 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
+	"github.com/s-sh1m0/u-22_procon/backend/internal/usecase"
+)
+
+// --- fakes ---
+
+type fakeAnalyzeUC struct {
+	jobID domain.JobID
+	err   error
+}
+
+func (f *fakeAnalyzeUC) Execute(_ context.Context, _ string, _ domain.PRInfo) (domain.JobID, error) {
+	return f.jobID, f.err
+}
+
+type fakeReadUC struct {
+	job      *domain.Job
+	analysis *domain.Analysis
+	jobErr   error
+	graphErr error
+}
+
+func (f *fakeReadUC) GetJob(_ context.Context, _ domain.JobID) (*domain.Job, error) {
+	return f.job, f.jobErr
+}
+
+func (f *fakeReadUC) GetGraph(_ context.Context, _ domain.JobID) (*domain.Analysis, error) {
+	return f.analysis, f.graphErr
+}
+
+// --- helpers ---
+
+func newEchoWithSession(sess *domain.Session) (*echo.Echo, echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/analyze", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	if sess != nil {
+		c.Set(contextKeySession, sess)
+	}
+	return e, c, rec
+}
+
+func validSession() *domain.Session {
+	return &domain.Session{ID: "sid", GitHubToken: "ghtok", UserLogin: "user", CreatedAt: time.Now()}
+}
+
+// --- parsePRURL tests ---
+
+func TestParsePRURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+		owner   string
+		repo    string
+		number  int
+	}{
+		{
+			name:   "valid https",
+			url:    "https://github.com/owner/repo/pull/123",
+			owner:  "owner",
+			repo:   "repo",
+			number: 123,
+		},
+		{
+			name:   "valid http",
+			url:    "http://github.com/owner/repo/pull/1",
+			owner:  "owner",
+			repo:   "repo",
+			number: 1,
+		},
+		{name: "wrong host", url: "https://gitlab.com/o/r/pull/1", wantErr: true},
+		{name: "wrong scheme", url: "ftp://github.com/o/r/pull/1", wantErr: true},
+		{name: "no number", url: "https://github.com/o/r/pull/", wantErr: true},
+		{name: "not pull", url: "https://github.com/o/r/issues/1", wantErr: true},
+		{name: "extra segment", url: "https://github.com/o/r/pull/1/files", wantErr: true},
+		{name: "zero number", url: "https://github.com/o/r/pull/0", wantErr: true},
+		{name: "negative number", url: "https://github.com/o/r/pull/-1", wantErr: true},
+		{name: "empty", url: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePRURL(tt.url)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil (result=%+v)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Owner != tt.owner || got.Repo != tt.repo || got.Number != tt.number {
+				t.Errorf("got %+v, want owner=%s repo=%s number=%d", got, tt.owner, tt.repo, tt.number)
+			}
+		})
+	}
+}
+
+// --- Analyze endpoint tests ---
+
+func TestAnalyze_Success(t *testing.T) {
+	analyzeUC := &fakeAnalyzeUC{jobID: "job-1"}
+	readUC := &fakeReadUC{job: &domain.Job{ID: "job-1", Status: domain.JobStatusPending}}
+	h := NewAnalysisHandler(analyzeUC, readUC)
+
+	e := echo.New()
+	body := `{"pr_url":"https://github.com/owner/repo/pull/42"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/analyze", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(contextKeySession, validSession())
+
+	if err := h.Analyze(c); err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp JobResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.JobID != "job-1" {
+		t.Errorf("unexpected job_id: %s", resp.JobID)
+	}
+}
+
+func TestAnalyze_InvalidURL(t *testing.T) {
+	h := NewAnalysisHandler(&fakeAnalyzeUC{}, &fakeReadUC{})
+
+	e := echo.New()
+	body := `{"pr_url":"https://github.com/bad-url"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/analyze", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(contextKeySession, validSession())
+
+	err := h.Analyze(c)
+	if he, ok := err.(*echo.HTTPError); !ok || he.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %v", err)
+	}
+}
+
+func TestAnalyze_NoSession(t *testing.T) {
+	h := NewAnalysisHandler(&fakeAnalyzeUC{}, &fakeReadUC{})
+
+	e := echo.New()
+	body := `{"pr_url":"https://github.com/owner/repo/pull/1"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/analyze", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	// no session set
+
+	err := h.Analyze(c)
+	if he, ok := err.(*echo.HTTPError); !ok || he.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %v", err)
+	}
+}
+
+// --- GetGraph endpoint tests ---
+
+func TestGetGraph_Success(t *testing.T) {
+	result := &domain.ClusterResult{
+		Clusters: []domain.Cluster{{ID: 0, Label: "pkg", Nodes: []domain.NodeID{"fn:A"}}},
+		Graph: domain.Graph{
+			Nodes: []domain.Node{{ID: "fn:A", Name: "A", Changed: true}},
+			Edges: []domain.Edge{},
+		},
+	}
+	analysis := &domain.Analysis{ID: "a1", Result: result}
+	h := NewAnalysisHandler(&fakeAnalyzeUC{}, &fakeReadUC{analysis: analysis})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/graph/job-1", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("jobId")
+	c.SetParamValues("job-1")
+
+	if err := h.GetGraph(c); err != nil {
+		t.Fatalf("GetGraph: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	var resp GraphResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Clusters) != 1 {
+		t.Errorf("expected 1 cluster, got %d", len(resp.Clusters))
+	}
+	if len(resp.Graph.Nodes) != 1 {
+		t.Errorf("expected 1 node, got %d", len(resp.Graph.Nodes))
+	}
+}
+
+func TestGetGraph_NotFound(t *testing.T) {
+	h := NewAnalysisHandler(&fakeAnalyzeUC{}, &fakeReadUC{graphErr: usecase.ErrJobNotFound})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/graph/missing", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("jobId")
+	c.SetParamValues("missing")
+
+	err := h.GetGraph(c)
+	if he, ok := err.(*echo.HTTPError); !ok || he.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %v", err)
+	}
+}
+
+func TestGetGraph_NotReady(t *testing.T) {
+	h := NewAnalysisHandler(&fakeAnalyzeUC{}, &fakeReadUC{graphErr: usecase.ErrJobNotReady})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/graph/pending-job", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("jobId")
+	c.SetParamValues("pending-job")
+
+	err := h.GetGraph(c)
+	if he, ok := err.(*echo.HTTPError); !ok || he.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %v", err)
+	}
+}

--- a/backend/internal/api/dto.go
+++ b/backend/internal/api/dto.go
@@ -1,8 +1,8 @@
 package api
 
-// TODO: リクエスト・レスポンスの JSON 構造体定義
+import "github.com/s-sh1m0/u-22_procon/backend/internal/domain"
 
-// AnalyzeRequest は POST /api/analyses のリクエスト
+// AnalyzeRequest は POST /api/analyze のリクエスト
 type AnalyzeRequest struct {
 	PRURL string `json:"pr_url"`
 }
@@ -18,4 +18,73 @@ type JobResponse struct {
 // MeResponse は GET /auth/me のレスポンス
 type MeResponse struct {
 	Login string `json:"login"`
+}
+
+// GraphResponse は GET /api/graph/:jobId のレスポンス
+type GraphResponse struct {
+	Clusters []ClusterDTO `json:"clusters"`
+	Graph    GraphDTO     `json:"graph"`
+}
+
+// ClusterDTO はクラスタの JSON 表現
+type ClusterDTO struct {
+	ID    int      `json:"id"`
+	Label string   `json:"label"`
+	Nodes []string `json:"nodes"`
+}
+
+// GraphDTO はグラフの JSON 表現
+type GraphDTO struct {
+	Nodes []NodeDTO `json:"nodes"`
+	Edges []EdgeDTO `json:"edges"`
+}
+
+// NodeDTO はノードの JSON 表現
+type NodeDTO struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Package string `json:"package"`
+	File    string `json:"file"`
+	Line    int    `json:"line"`
+	Changed bool   `json:"changed"`
+}
+
+// EdgeDTO はエッジの JSON 表現
+type EdgeDTO struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// toGraphResponse は domain.ClusterResult を GraphResponse に変換する。
+func toGraphResponse(r *domain.ClusterResult) GraphResponse {
+	clusters := make([]ClusterDTO, len(r.Clusters))
+	for i, c := range r.Clusters {
+		nodes := make([]string, len(c.Nodes))
+		for j, n := range c.Nodes {
+			nodes[j] = string(n)
+		}
+		clusters[i] = ClusterDTO{ID: c.ID, Label: c.Label, Nodes: nodes}
+	}
+
+	nodes := make([]NodeDTO, len(r.Graph.Nodes))
+	for i, n := range r.Graph.Nodes {
+		nodes[i] = NodeDTO{
+			ID:      string(n.ID),
+			Name:    n.Name,
+			Package: n.Package,
+			File:    n.File,
+			Line:    n.Line,
+			Changed: n.Changed,
+		}
+	}
+
+	edges := make([]EdgeDTO, len(r.Graph.Edges))
+	for i, e := range r.Graph.Edges {
+		edges[i] = EdgeDTO{From: string(e.From), To: string(e.To)}
+	}
+
+	return GraphResponse{
+		Clusters: clusters,
+		Graph:    GraphDTO{Nodes: nodes, Edges: edges},
+	}
 }

--- a/backend/internal/api/job_handler.go
+++ b/backend/internal/api/job_handler.go
@@ -1,3 +1,43 @@
 package api
 
-// TODO: GET /api/jobs/:id（フロントエンドのポーリング用）
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
+)
+
+// JobHandler は GET /api/jobs/:id のハンドラ。
+type JobHandler struct {
+	read readUseCase
+}
+
+// NewJobHandler は JobHandler を返す。
+func NewJobHandler(read readUseCase) *JobHandler {
+	return &JobHandler{read: read}
+}
+
+// Get は GET /api/jobs/:id を処理する。
+func (h *JobHandler) Get(c echo.Context) error {
+	id := c.Param("id")
+	if id == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "id is required")
+	}
+
+	j, err := h.read.GetJob(c.Request().Context(), domain.JobID(id))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("get job: %v", err))
+	}
+	if j == nil {
+		return echo.NewHTTPError(http.StatusNotFound, "job not found")
+	}
+
+	return c.JSON(http.StatusOK, JobResponse{
+		JobID:      string(j.ID),
+		Status:     string(j.Status),
+		AnalysisID: string(j.AnalysisID),
+		Error:      j.Error,
+	})
+}

--- a/backend/internal/api/job_handler_test.go
+++ b/backend/internal/api/job_handler_test.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
+)
+
+func TestJobHandler_Get_Success(t *testing.T) {
+	job := &domain.Job{
+		ID:         "job-1",
+		Status:     domain.JobStatusDone,
+		AnalysisID: "analysis-1",
+	}
+	h := NewJobHandler(&fakeReadUC{job: job})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/jobs/job-1", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("job-1")
+
+	if err := h.Get(c); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	var resp JobResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.JobID != "job-1" || resp.Status != "done" || resp.AnalysisID != "analysis-1" {
+		t.Errorf("unexpected response: %+v", resp)
+	}
+}
+
+func TestJobHandler_Get_NotFound(t *testing.T) {
+	h := NewJobHandler(&fakeReadUC{job: nil})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/jobs/missing", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("missing")
+
+	err := h.Get(c)
+	if he, ok := err.(*echo.HTTPError); !ok || he.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %v", err)
+	}
+}
+
+func TestJobHandler_Get_Pending(t *testing.T) {
+	job := &domain.Job{ID: "job-2", Status: domain.JobStatusPending}
+	h := NewJobHandler(&fakeReadUC{job: job})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/jobs/job-2", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("job-2")
+
+	if err := h.Get(c); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	var resp JobResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.AnalysisID != "" {
+		t.Errorf("analysis_id should be omitted for pending, got %q", resp.AnalysisID)
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -11,8 +11,12 @@ import (
 
 // NewRouter は Echo インスタンスを生成し全ルートを登録して返す。
 // 認証保護が必要なエンドポイントには RequireAuth を適用する。
-// /api/* ルートは Issue #3 以降で追加予定。
-func NewRouter(authHandler *AuthHandler, sessions domain.SessionRepository) *echo.Echo {
+func NewRouter(
+	authHandler *AuthHandler,
+	analysisHandler *AnalysisHandler,
+	jobHandler *JobHandler,
+	sessions domain.SessionRepository,
+) *echo.Echo {
 	e := echo.New()
 	e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
 		LogStatus:  true,
@@ -31,6 +35,11 @@ func NewRouter(authHandler *AuthHandler, sessions domain.SessionRepository) *ech
 	auth.GET("/github/callback", authHandler.Callback)
 	auth.POST("/logout", authHandler.Logout)
 	auth.GET("/me", authHandler.Me, RequireAuth(sessions))
+
+	apiG := e.Group("/api", RequireAuth(sessions))
+	apiG.POST("/analyze", analysisHandler.Analyze)
+	apiG.GET("/jobs/:id", jobHandler.Get)
+	apiG.GET("/graph/:jobId", analysisHandler.GetGraph)
 
 	return e
 }

--- a/backend/internal/infra/analyzer/clone.go
+++ b/backend/internal/infra/analyzer/clone.go
@@ -75,18 +75,21 @@ func (c *GitCloner) Clone(ctx context.Context, req CloneRequest) (*ClonedRepo, e
 		return nil, err
 	}
 
-	remoteURL := fmt.Sprintf("https://github.com/%s/%s.git", req.Owner, req.Repo)
+	// token がある場合はURL認証を使う（一時ディレクトリ内のみで完結するため安全）
+	// トークンはリモート URL に埋め込んでコンテナ内の一時ディレクトリに git remote add する。
+	// git remote の URL はホスト外に露出せず、ClonedRepo.Cleanup() で削除される。
+	var remoteURL string
+	if req.Token != "" {
+		remoteURL = fmt.Sprintf("https://oauth2:%s@github.com/%s/%s.git", req.Token, req.Owner, req.Repo)
+	} else {
+		remoteURL = fmt.Sprintf("https://github.com/%s/%s.git", req.Owner, req.Repo)
+	}
 	if err := c.runGit(ctx, gitBin, dir, "remote", "add", "origin", remoteURL); err != nil {
 		_ = cleanup()
 		return nil, err
 	}
 
-	// tokenはhttp.extraheaderで渡す（コマンド引数経由なのでgit configに永続しない）
-	fetchArgs := []string{"fetch", "--depth=1", "--no-tags", "--filter=blob:none"}
-	if req.Token != "" {
-		fetchArgs = append([]string{"-c", "http.extraheader=Authorization: bearer " + req.Token, "-c", "credential.helper="}, fetchArgs...)
-	}
-	fetchArgs = append(fetchArgs, "origin", req.SHA)
+	fetchArgs := []string{"fetch", "--depth=1", "--no-tags", "--filter=blob:none", "origin", req.SHA}
 	if err := c.runGit(ctx, gitBin, dir, fetchArgs...); err != nil {
 		_ = cleanup()
 		return nil, err

--- a/backend/internal/infra/analyzer/clone.go
+++ b/backend/internal/infra/analyzer/clone.go
@@ -113,6 +113,8 @@ func (c *GitCloner) Clone(ctx context.Context, req CloneRequest) (*ClonedRepo, e
 func (c *GitCloner) runGit(ctx context.Context, gitBin, dir string, args ...string) error {
 	cmd := exec.CommandContext(ctx, gitBin, args...)
 	cmd.Dir = dir
+	// GIT_TERMINAL_PROMPT=0 で認証プロンプトを抑止する（コンテナ環境で tty がない場合に必要）
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr

--- a/backend/internal/infra/analyzer/source_tree.go
+++ b/backend/internal/infra/analyzer/source_tree.go
@@ -49,10 +49,13 @@ func (s *SourceTree) Prepare(ctx context.Context, pr domain.PRInfo, token string
 		return nil, fmt.Errorf("analyzer: clone %s/%s@%s: %w", pr.Owner, pr.Repo, pr.HeadSHA, err)
 	}
 
-	loadDir, err := findGoModRoot(cloned.RootDir)
+	// go.mod を持つサブディレクトリを特定し、そこを基点にパッケージをロードする。
+	// clonedRoot はリポジトリルート（GitHub API の相対パス基点）、loadDir は go.mod の親。
+	clonedRoot := cloned.RootDir
+	loadDir, err := findGoModRoot(clonedRoot)
 	if err != nil {
 		_ = cloned.Cleanup()
-		return nil, fmt.Errorf("analyzer: find go.mod in %s: %w", cloned.RootDir, err)
+		return nil, fmt.Errorf("analyzer: find go.mod in %s: %w", clonedRoot, err)
 	}
 
 	result, err := s.Loader.Load(ctx, loadDir)
@@ -61,7 +64,8 @@ func (s *SourceTree) Prepare(ctx context.Context, pr domain.PRInfo, token string
 		return nil, fmt.Errorf("analyzer: load packages at %s: %w", loadDir, err)
 	}
 
-	changedPkgs := IdentifyChangedPackages(loadDir, result.Packages, changed)
+	// GitHub API の changed ファイルパスはリポジトリルート相対なので clonedRoot を基点にする。
+	changedPkgs := IdentifyChangedPackages(clonedRoot, result.Packages, changed)
 
 	return &PreparedSource{
 		RootDir:         loadDir,

--- a/backend/internal/infra/analyzer/source_tree.go
+++ b/backend/internal/infra/analyzer/source_tree.go
@@ -3,6 +3,10 @@ package analyzer
 import (
 	"context"
 	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"golang.org/x/tools/go/packages"
 
@@ -33,6 +37,7 @@ func NewSourceTree(c Cloner, l PackageLoader) *SourceTree {
 // Prepare は clone → load → 変更パッケージ特定 を一気に実施する。
 // Loadが失敗したときはCloneのCleanupを内部で呼んでから返す（呼び出し側に部分状態を渡さない）。
 // 成功時のみPreparedSource.Cleanupが返り、呼び出し側がdeferで呼ぶ責務を持つ。
+// モノレポ対応: cloneルートでパッケージが見つからない場合、go.mod を持つサブディレクトリを自動検出する。
 func (s *SourceTree) Prepare(ctx context.Context, pr domain.PRInfo, token string, changed []domain.ChangedFile) (*PreparedSource, error) {
 	cloned, err := s.Cloner.Clone(ctx, CloneRequest{
 		Owner: pr.Owner,
@@ -44,19 +49,59 @@ func (s *SourceTree) Prepare(ctx context.Context, pr domain.PRInfo, token string
 		return nil, fmt.Errorf("analyzer: clone %s/%s@%s: %w", pr.Owner, pr.Repo, pr.HeadSHA, err)
 	}
 
-	result, err := s.Loader.Load(ctx, cloned.RootDir)
+	loadDir, err := findGoModRoot(cloned.RootDir)
 	if err != nil {
 		_ = cloned.Cleanup()
-		return nil, fmt.Errorf("analyzer: load packages at %s: %w", cloned.RootDir, err)
+		return nil, fmt.Errorf("analyzer: find go.mod in %s: %w", cloned.RootDir, err)
 	}
 
-	changedPkgs := IdentifyChangedPackages(cloned.RootDir, result.Packages, changed)
+	result, err := s.Loader.Load(ctx, loadDir)
+	if err != nil {
+		_ = cloned.Cleanup()
+		return nil, fmt.Errorf("analyzer: load packages at %s: %w", loadDir, err)
+	}
+
+	changedPkgs := IdentifyChangedPackages(loadDir, result.Packages, changed)
 
 	return &PreparedSource{
-		RootDir:         cloned.RootDir,
+		RootDir:         loadDir,
 		Packages:        result.Packages,
 		LoadErrors:      result.Errors,
 		ChangedPackages: changedPkgs,
 		Cleanup:         cloned.Cleanup,
 	}, nil
+}
+
+// findGoModRoot はルートから go.mod を探して最も浅い（ルートに近い）ディレクトリを返す。
+// ルート直下に go.mod があればそのまま返す。
+func findGoModRoot(root string) (string, error) {
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err == nil {
+		return root, nil
+	}
+
+	var found []string
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() && strings.HasPrefix(d.Name(), ".") {
+			return filepath.SkipDir
+		}
+		if !d.IsDir() && d.Name() == "go.mod" {
+			found = append(found, filepath.Dir(path))
+		}
+		return nil
+	})
+
+	if len(found) == 0 {
+		return "", fmt.Errorf("%w: no go.mod found under %s", ErrNoPackages, root)
+	}
+	// 最も浅い（パス区切りが最小の）ディレクトリを優先
+	shallowest := found[0]
+	for _, d := range found[1:] {
+		if strings.Count(d, string(filepath.Separator)) < strings.Count(shallowest, string(filepath.Separator)) {
+			shallowest = d
+		}
+	}
+	return shallowest, nil
 }

--- a/backend/internal/infra/job/queue.go
+++ b/backend/internal/infra/job/queue.go
@@ -1,3 +1,35 @@
 package job
 
-// TODO: goroutine + buffered channel によるジョブキューの実装
+import "github.com/s-sh1m0/u-22_procon/backend/internal/domain"
+
+// Item はジョブキューの 1 要素。Token は in-memory のみで永続化しない。
+type Item struct {
+	JobID domain.JobID
+	Token string
+}
+
+// Queue は in-process のジョブキュー。buffered channel で実装する。
+type Queue struct {
+	ch chan Item
+}
+
+// NewQueue は容量 buf のキューを返す。
+func NewQueue(buf int) *Queue {
+	return &Queue{ch: make(chan Item, buf)}
+}
+
+// Enqueue はジョブをキューに追加する。満杯の場合はブロックする。
+// この関数シグネチャは usecase.JobEnqueuer インターフェースを充足する。
+func (q *Queue) Enqueue(jobID domain.JobID, token string) {
+	q.ch <- Item{JobID: jobID, Token: token}
+}
+
+// Recv はキューの受信チャネルを返す。
+func (q *Queue) Recv() <-chan Item {
+	return q.ch
+}
+
+// Close はキューをクローズし、ワーカーに終了を通知する。
+func (q *Queue) Close() {
+	close(q.ch)
+}

--- a/backend/internal/infra/job/worker.go
+++ b/backend/internal/infra/job/worker.go
@@ -1,3 +1,158 @@
 package job
 
-// TODO: キューからジョブを受け取り github → analyzer → cluster → store の順に処理する
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
+	"github.com/s-sh1m0/u-22_procon/backend/internal/infra/analyzer"
+	"github.com/s-sh1m0/u-22_procon/backend/internal/infra/cluster"
+)
+
+// jobStore はワーカーが使うジョブ永続化インターフェース。
+type jobStore interface {
+	FindByID(ctx context.Context, id domain.JobID) (*domain.Job, error)
+	UpdateStatus(ctx context.Context, id domain.JobID, status domain.JobStatus, errMsg string) error
+	UpdateAnalysisID(ctx context.Context, id domain.JobID, analysisID domain.AnalysisID) error
+}
+
+// sourceTreePreparer はワーカーが使うソースツリー準備インターフェース。
+type sourceTreePreparer interface {
+	Prepare(ctx context.Context, pr domain.PRInfo, token string, changed []domain.ChangedFile) (*analyzer.PreparedSource, error)
+}
+
+// Worker はキューからジョブを受け取り解析パイプラインを実行する。
+type Worker struct {
+	queue      *Queue
+	jobs       jobStore
+	analyses   domain.AnalysisRepository
+	prRepo     domain.PRRepository
+	sourceTree sourceTreePreparer
+	cgBuilder  analyzer.CallGraphBuilder
+	clusterer  cluster.Clusterer
+	now        func() time.Time
+	newID      func() string
+}
+
+// NewWorker は Worker を返す。
+func NewWorker(
+	queue *Queue,
+	jobs jobStore,
+	analyses domain.AnalysisRepository,
+	prRepo domain.PRRepository,
+	sourceTree sourceTreePreparer,
+	cgBuilder analyzer.CallGraphBuilder,
+	clusterer cluster.Clusterer,
+) *Worker {
+	return &Worker{
+		queue:      queue,
+		jobs:       jobs,
+		analyses:   analyses,
+		prRepo:     prRepo,
+		sourceTree: sourceTree,
+		cgBuilder:  cgBuilder,
+		clusterer:  clusterer,
+		now:        time.Now,
+		newID:      workerRandomID,
+	}
+}
+
+// Run はジョブキューを読み込み、ctx がキャンセルされるかキューが閉じるまでブロックする。
+func (w *Worker) Run(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case item, ok := <-w.queue.Recv():
+			if !ok {
+				return nil
+			}
+			w.process(ctx, item)
+		}
+	}
+}
+
+func (w *Worker) process(ctx context.Context, item Item) {
+	jobID := item.JobID
+	fail := func(err error) {
+		log.Printf("worker: job %s failed: %v", jobID, err)
+		_ = w.jobs.UpdateStatus(ctx, jobID, domain.JobStatusError, err.Error())
+	}
+
+	if err := w.jobs.UpdateStatus(ctx, jobID, domain.JobStatusRunning, ""); err != nil {
+		log.Printf("worker: failed to mark job %s running: %v", jobID, err)
+	}
+
+	j, err := w.jobs.FindByID(ctx, jobID)
+	if err != nil {
+		fail(fmt.Errorf("find job: %w", err))
+		return
+	}
+	if j == nil {
+		log.Printf("worker: job %s not found, skipping", jobID)
+		return
+	}
+
+	prInfo, err := w.prRepo.GetPR(ctx, item.Token, j.PR.Owner, j.PR.Repo, j.PR.Number)
+	if err != nil {
+		fail(fmt.Errorf("get PR: %w", err))
+		return
+	}
+
+	changed, err := w.prRepo.ListChangedGoFiles(ctx, item.Token, j.PR.Owner, j.PR.Repo, j.PR.Number)
+	if err != nil {
+		fail(fmt.Errorf("list changed files: %w", err))
+		return
+	}
+
+	prepared, err := w.sourceTree.Prepare(ctx, *prInfo, item.Token, changed)
+	if err != nil {
+		fail(fmt.Errorf("prepare source: %w", err))
+		return
+	}
+	defer func() { _ = prepared.Cleanup() }()
+
+	graph, err := w.cgBuilder.Build(ctx, prepared.Packages, prepared.ChangedPackages)
+	if err != nil {
+		fail(fmt.Errorf("build callgraph: %w", err))
+		return
+	}
+
+	result, err := w.clusterer.Cluster(ctx, graph)
+	if err != nil {
+		fail(fmt.Errorf("cluster: %w", err))
+		return
+	}
+
+	analysisID := domain.AnalysisID(w.newID())
+	a := &domain.Analysis{
+		ID:        analysisID,
+		PR:        *prInfo,
+		Result:    result,
+		CreatedAt: w.now().UTC(),
+	}
+	if err := w.analyses.Save(ctx, a); err != nil {
+		fail(fmt.Errorf("save analysis: %w", err))
+		return
+	}
+
+	if err := w.jobs.UpdateAnalysisID(ctx, jobID, analysisID); err != nil {
+		fail(fmt.Errorf("update analysis_id: %w", err))
+		return
+	}
+	if err := w.jobs.UpdateStatus(ctx, jobID, domain.JobStatusDone, ""); err != nil {
+		log.Printf("worker: failed to mark job %s done: %v", jobID, err)
+	}
+}
+
+func workerRandomID() string {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		panic(fmt.Sprintf("workerRandomID: %v", err))
+	}
+	return base64.RawURLEncoding.EncodeToString(buf)
+}

--- a/backend/internal/infra/job/worker_test.go
+++ b/backend/internal/infra/job/worker_test.go
@@ -122,6 +122,8 @@ func (c *fakeClusterer) Cluster(_ context.Context, _ *domain.Graph) (*domain.Clu
 
 // --- helpers ---
 
+const fixedID = "fixed-id"
+
 func newWorkerWithFakes(
 	jobs *fakeJobStore,
 	analyses *fakeAnalysisRepo,
@@ -133,7 +135,7 @@ func newWorkerWithFakes(
 	q := NewQueue(1)
 	w := NewWorker(q, jobs, analyses, prRepo, sourceTree, cgBuilder, clusterer)
 	w.now = func() time.Time { return time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC) }
-	w.newID = func() string { return "fixed-id" }
+	w.newID = func() string { return fixedID }
 	return w
 }
 
@@ -177,14 +179,14 @@ func TestWorker_HappyPath(t *testing.T) {
 	if j.Status != domain.JobStatusDone {
 		t.Errorf("expected done, got %s", j.Status)
 	}
-	if j.AnalysisID != "fixed-id" {
+	if j.AnalysisID != fixedID {
 		t.Errorf("expected fixed-id, got %s", j.AnalysisID)
 	}
 	// analysis should be saved
 	if len(analyses.saved) != 1 {
 		t.Fatalf("expected 1 analysis saved, got %d", len(analyses.saved))
 	}
-	if analyses.saved[0].ID != "fixed-id" {
+	if analyses.saved[0].ID != fixedID {
 		t.Errorf("unexpected analysis ID: %s", analyses.saved[0].ID)
 	}
 }

--- a/backend/internal/infra/job/worker_test.go
+++ b/backend/internal/infra/job/worker_test.go
@@ -1,0 +1,266 @@
+package job
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"golang.org/x/tools/go/packages"
+
+	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
+	"github.com/s-sh1m0/u-22_procon/backend/internal/infra/analyzer"
+)
+
+// --- fakes ---
+
+type fakeJobStore struct {
+	jobs        map[domain.JobID]*domain.Job
+	statusCalls []struct {
+		id     domain.JobID
+		status domain.JobStatus
+		errMsg string
+	}
+	analysisIDCalls []struct {
+		id         domain.JobID
+		analysisID domain.AnalysisID
+	}
+	findErr error
+}
+
+func newFakeJobStore() *fakeJobStore {
+	return &fakeJobStore{jobs: make(map[domain.JobID]*domain.Job)}
+}
+
+func (s *fakeJobStore) FindByID(_ context.Context, id domain.JobID) (*domain.Job, error) {
+	if s.findErr != nil {
+		return nil, s.findErr
+	}
+	return s.jobs[id], nil
+}
+
+func (s *fakeJobStore) UpdateStatus(_ context.Context, id domain.JobID, status domain.JobStatus, errMsg string) error {
+	s.statusCalls = append(s.statusCalls, struct {
+		id     domain.JobID
+		status domain.JobStatus
+		errMsg string
+	}{id, status, errMsg})
+	if j, ok := s.jobs[id]; ok {
+		j.Status = status
+	}
+	return nil
+}
+
+func (s *fakeJobStore) UpdateAnalysisID(_ context.Context, id domain.JobID, analysisID domain.AnalysisID) error {
+	s.analysisIDCalls = append(s.analysisIDCalls, struct {
+		id         domain.JobID
+		analysisID domain.AnalysisID
+	}{id, analysisID})
+	if j, ok := s.jobs[id]; ok {
+		j.AnalysisID = analysisID
+	}
+	return nil
+}
+
+type fakeAnalysisRepo struct {
+	saved []*domain.Analysis
+}
+
+func (r *fakeAnalysisRepo) Save(_ context.Context, a *domain.Analysis) error {
+	r.saved = append(r.saved, a)
+	return nil
+}
+
+func (r *fakeAnalysisRepo) FindByID(_ context.Context, _ domain.AnalysisID) (*domain.Analysis, error) {
+	return nil, nil
+}
+
+func (r *fakeAnalysisRepo) FindByPR(_ context.Context, _ domain.PRInfo) (*domain.Analysis, error) {
+	return nil, nil
+}
+
+type fakePRRepo struct {
+	prInfo  *domain.PRInfo
+	changed []domain.ChangedFile
+	err     error
+}
+
+func (r *fakePRRepo) GetPR(_ context.Context, _, _, _ string, _ int) (*domain.PRInfo, error) {
+	return r.prInfo, r.err
+}
+
+func (r *fakePRRepo) ListChangedGoFiles(_ context.Context, _, _, _ string, _ int) ([]domain.ChangedFile, error) {
+	return r.changed, r.err
+}
+
+type fakeSourceTree struct {
+	prepared *analyzer.PreparedSource
+	err      error
+}
+
+func (s *fakeSourceTree) Prepare(_ context.Context, _ domain.PRInfo, _ string, _ []domain.ChangedFile) (*analyzer.PreparedSource, error) {
+	return s.prepared, s.err
+}
+
+type fakeCGBuilder struct {
+	graph *domain.Graph
+	err   error
+}
+
+func (b *fakeCGBuilder) Build(_ context.Context, _ []*packages.Package, _ []string) (*domain.Graph, error) {
+	return b.graph, b.err
+}
+
+type fakeClusterer struct {
+	result *domain.ClusterResult
+	err    error
+}
+
+func (c *fakeClusterer) Cluster(_ context.Context, _ *domain.Graph) (*domain.ClusterResult, error) {
+	return c.result, c.err
+}
+
+// --- helpers ---
+
+func newWorkerWithFakes(
+	jobs *fakeJobStore,
+	analyses *fakeAnalysisRepo,
+	prRepo *fakePRRepo,
+	sourceTree *fakeSourceTree,
+	cgBuilder *fakeCGBuilder,
+	clusterer *fakeClusterer,
+) *Worker {
+	q := NewQueue(1)
+	w := NewWorker(q, jobs, analyses, prRepo, sourceTree, cgBuilder, clusterer)
+	w.now = func() time.Time { return time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC) }
+	w.newID = func() string { return "fixed-id" }
+	return w
+}
+
+// --- tests ---
+
+func TestWorker_HappyPath(t *testing.T) {
+	prInfo := &domain.PRInfo{Owner: "o", Repo: "r", Number: 1, HeadSHA: "sha"}
+	graph := &domain.Graph{
+		Nodes: []domain.Node{{ID: "fn:A", Name: "A"}},
+	}
+	result := &domain.ClusterResult{
+		Clusters: []domain.Cluster{{ID: 0, Label: "pkg"}},
+		Graph:    *graph,
+	}
+
+	jobs := newFakeJobStore()
+	jobs.jobs["job-1"] = &domain.Job{
+		ID:     "job-1",
+		Status: domain.JobStatusPending,
+		PR:     domain.PRInfo{Owner: "o", Repo: "r", Number: 1},
+	}
+	analyses := &fakeAnalysisRepo{}
+
+	w := newWorkerWithFakes(
+		jobs,
+		analyses,
+		&fakePRRepo{prInfo: prInfo, changed: []domain.ChangedFile{}},
+		&fakeSourceTree{prepared: &analyzer.PreparedSource{
+			Packages:        nil,
+			ChangedPackages: nil,
+			Cleanup:         func() error { return nil },
+		}},
+		&fakeCGBuilder{graph: graph},
+		&fakeClusterer{result: result},
+	)
+
+	w.process(context.Background(), Item{JobID: "job-1", Token: "tok"})
+
+	// job should be done
+	j := jobs.jobs["job-1"]
+	if j.Status != domain.JobStatusDone {
+		t.Errorf("expected done, got %s", j.Status)
+	}
+	if j.AnalysisID != "fixed-id" {
+		t.Errorf("expected fixed-id, got %s", j.AnalysisID)
+	}
+	// analysis should be saved
+	if len(analyses.saved) != 1 {
+		t.Fatalf("expected 1 analysis saved, got %d", len(analyses.saved))
+	}
+	if analyses.saved[0].ID != "fixed-id" {
+		t.Errorf("unexpected analysis ID: %s", analyses.saved[0].ID)
+	}
+}
+
+func TestWorker_PRRepoError_MarksJobError(t *testing.T) {
+	jobs := newFakeJobStore()
+	jobs.jobs["job-2"] = &domain.Job{
+		ID:     "job-2",
+		Status: domain.JobStatusPending,
+		PR:     domain.PRInfo{Owner: "o", Repo: "r", Number: 1},
+	}
+	analyses := &fakeAnalysisRepo{}
+
+	w := newWorkerWithFakes(
+		jobs, analyses,
+		&fakePRRepo{err: errors.New("github API error")},
+		&fakeSourceTree{},
+		&fakeCGBuilder{},
+		&fakeClusterer{},
+	)
+
+	w.process(context.Background(), Item{JobID: "job-2", Token: "tok"})
+
+	j := jobs.jobs["job-2"]
+	if j.Status != domain.JobStatusError {
+		t.Errorf("expected error status, got %s", j.Status)
+	}
+}
+
+func TestWorker_ContextCancel_StopsLoop(t *testing.T) {
+	q := NewQueue(1)
+	jobs := newFakeJobStore()
+	analyses := &fakeAnalysisRepo{}
+	w := &Worker{
+		queue:    q,
+		jobs:     jobs,
+		analyses: analyses,
+		prRepo:   &fakePRRepo{},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx) }()
+
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("expected Canceled, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("Run did not stop after context cancel")
+	}
+}
+
+func TestWorker_QueueClose_StopsLoop(t *testing.T) {
+	q := NewQueue(1)
+	jobs := newFakeJobStore()
+	analyses := &fakeAnalysisRepo{}
+	w := &Worker{
+		queue:    q,
+		jobs:     jobs,
+		analyses: analyses,
+		prRepo:   &fakePRRepo{},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- w.Run(context.Background()) }()
+
+	q.Close()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("expected nil on close, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("Run did not stop after queue close")
+	}
+}

--- a/backend/internal/infra/store/analysis_repo.go
+++ b/backend/internal/infra/store/analysis_repo.go
@@ -2,26 +2,99 @@ package store
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
 
 	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
 )
 
 // AnalysisRepo は domain.AnalysisRepository の SQLite 実装
 type AnalysisRepo struct {
-	// TODO: *sql.DB を埋め込む
+	db *sql.DB
 }
 
+// NewAnalysisRepo は AnalysisRepo を返す。
+func NewAnalysisRepo(db *sql.DB) *AnalysisRepo {
+	return &AnalysisRepo{db: db}
+}
+
+// Save は解析結果を analyses テーブルに保存する。result は JSON でシリアライズする。
 func (r *AnalysisRepo) Save(ctx context.Context, a *domain.Analysis) error {
-	// TODO: implement
+	resultJSON, err := json.Marshal(a.Result)
+	if err != nil {
+		return fmt.Errorf("marshal analysis result: %w", err)
+	}
+	_, err = r.db.ExecContext(ctx,
+		`INSERT INTO analyses (id, owner, repo, pr_number, result, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		string(a.ID), a.PR.Owner, a.PR.Repo, a.PR.Number, string(resultJSON), a.CreatedAt.UTC(),
+	)
+	if err != nil {
+		return fmt.Errorf("insert analysis: %w", err)
+	}
 	return nil
 }
 
+// FindByID は ID で解析結果を返す。存在しない場合は (nil, nil) を返す。
 func (r *AnalysisRepo) FindByID(ctx context.Context, id domain.AnalysisID) (*domain.Analysis, error) {
-	// TODO: implement
-	return nil, nil
+	var (
+		owner      string
+		repo       string
+		prNumber   int
+		resultJSON string
+		createdAt  time.Time
+	)
+	err := r.db.QueryRowContext(ctx,
+		`SELECT owner, repo, pr_number, result, created_at FROM analyses WHERE id = ?`,
+		string(id),
+	).Scan(&owner, &repo, &prNumber, &resultJSON, &createdAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query analysis: %w", err)
+	}
+
+	var result domain.ClusterResult
+	if err := json.Unmarshal([]byte(resultJSON), &result); err != nil {
+		return nil, fmt.Errorf("unmarshal analysis result: %w", err)
+	}
+	return &domain.Analysis{
+		ID:        id,
+		PR:        domain.PRInfo{Owner: owner, Repo: repo, Number: prNumber},
+		Result:    &result,
+		CreatedAt: createdAt,
+	}, nil
 }
 
+// FindByPR は同一 PR の最新解析結果を返す。存在しない場合は (nil, nil) を返す。
 func (r *AnalysisRepo) FindByPR(ctx context.Context, pr domain.PRInfo) (*domain.Analysis, error) {
-	// TODO: implement
-	return nil, nil
+	var (
+		id         string
+		resultJSON string
+		createdAt  time.Time
+	)
+	err := r.db.QueryRowContext(ctx,
+		`SELECT id, result, created_at FROM analyses WHERE owner=? AND repo=? AND pr_number=? ORDER BY created_at DESC LIMIT 1`,
+		pr.Owner, pr.Repo, pr.Number,
+	).Scan(&id, &resultJSON, &createdAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query analysis by PR: %w", err)
+	}
+
+	var result domain.ClusterResult
+	if err := json.Unmarshal([]byte(resultJSON), &result); err != nil {
+		return nil, fmt.Errorf("unmarshal analysis result: %w", err)
+	}
+	return &domain.Analysis{
+		ID:        domain.AnalysisID(id),
+		PR:        pr,
+		Result:    &result,
+		CreatedAt: createdAt,
+	}, nil
 }

--- a/backend/internal/infra/store/analysis_repo_test.go
+++ b/backend/internal/infra/store/analysis_repo_test.go
@@ -13,7 +13,7 @@ func TestAnalysisRepo_SaveAndFindByID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	repo := NewAnalysisRepo(db)
 	ctx := context.Background()
@@ -67,7 +67,7 @@ func TestAnalysisRepo_FindByID_NotFound(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	repo := NewAnalysisRepo(db)
 	got, err := repo.FindByID(context.Background(), "nonexistent")
@@ -84,7 +84,7 @@ func TestAnalysisRepo_FindByPR_ReturnsLatest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	repo := NewAnalysisRepo(db)
 	ctx := context.Background()
@@ -118,7 +118,7 @@ func TestAnalysisRepo_FindByPR_NotFound(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	repo := NewAnalysisRepo(db)
 	got, err := repo.FindByPR(context.Background(), domain.PRInfo{Owner: "o", Repo: "r", Number: 1})

--- a/backend/internal/infra/store/analysis_repo_test.go
+++ b/backend/internal/infra/store/analysis_repo_test.go
@@ -1,0 +1,131 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
+)
+
+func TestAnalysisRepo_SaveAndFindByID(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	repo := NewAnalysisRepo(db)
+	ctx := context.Background()
+
+	result := &domain.ClusterResult{
+		Clusters: []domain.Cluster{
+			{ID: 0, Label: "pkg/foo", Nodes: []domain.NodeID{"fn:A", "fn:B"}},
+		},
+		Graph: domain.Graph{
+			Nodes: []domain.Node{
+				{ID: "fn:A", Name: "A", Package: "pkg/foo", File: "foo.go", Line: 10, Changed: true},
+				{ID: "fn:B", Name: "B", Package: "pkg/foo", File: "foo.go", Line: 20, Changed: false},
+			},
+			Edges: []domain.Edge{{From: "fn:A", To: "fn:B"}},
+		},
+	}
+	a := &domain.Analysis{
+		ID:        "test-analysis-id",
+		PR:        domain.PRInfo{Owner: "owner", Repo: "repo", Number: 42},
+		Result:    result,
+		CreatedAt: time.Now().UTC().Truncate(time.Second),
+	}
+
+	if err := repo.Save(ctx, a); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := repo.FindByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("FindByID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil analysis")
+	}
+	if got.PR.Owner != "owner" || got.PR.Repo != "repo" || got.PR.Number != 42 {
+		t.Errorf("PR mismatch: got %+v", got.PR)
+	}
+	if len(got.Result.Clusters) != 1 || got.Result.Clusters[0].Label != "pkg/foo" {
+		t.Errorf("Clusters mismatch: got %+v", got.Result.Clusters)
+	}
+	if len(got.Result.Graph.Nodes) != 2 {
+		t.Errorf("Nodes count mismatch: got %d", len(got.Result.Graph.Nodes))
+	}
+	if len(got.Result.Graph.Edges) != 1 {
+		t.Errorf("Edges count mismatch: got %d", len(got.Result.Graph.Edges))
+	}
+}
+
+func TestAnalysisRepo_FindByID_NotFound(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	repo := NewAnalysisRepo(db)
+	got, err := repo.FindByID(context.Background(), "nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}
+
+func TestAnalysisRepo_FindByPR_ReturnsLatest(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	repo := NewAnalysisRepo(db)
+	ctx := context.Background()
+	pr := domain.PRInfo{Owner: "owner", Repo: "repo", Number: 1}
+
+	emptyResult := &domain.ClusterResult{}
+
+	old := &domain.Analysis{ID: "old", PR: pr, Result: emptyResult, CreatedAt: time.Now().UTC().Add(-time.Hour)}
+	newer := &domain.Analysis{ID: "newer", PR: pr, Result: emptyResult, CreatedAt: time.Now().UTC()}
+
+	for _, a := range []*domain.Analysis{old, newer} {
+		if err := repo.Save(ctx, a); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+	}
+
+	got, err := repo.FindByPR(ctx, pr)
+	if err != nil {
+		t.Fatalf("FindByPR: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil analysis")
+	}
+	if got.ID != "newer" {
+		t.Errorf("expected newest analysis, got id=%s", got.ID)
+	}
+}
+
+func TestAnalysisRepo_FindByPR_NotFound(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	repo := NewAnalysisRepo(db)
+	got, err := repo.FindByPR(context.Background(), domain.PRInfo{Owner: "o", Repo: "r", Number: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}

--- a/backend/internal/infra/store/job_repo.go
+++ b/backend/internal/infra/store/job_repo.go
@@ -2,26 +2,122 @@ package store
 
 import (
 	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
 
 	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
 )
 
 // JobRepo は domain.JobRepository の SQLite 実装
 type JobRepo struct {
-	// TODO: *sql.DB を埋め込む
+	db *sql.DB
 }
 
+// NewJobRepo は JobRepo を返す。
+func NewJobRepo(db *sql.DB) *JobRepo {
+	return &JobRepo{db: db}
+}
+
+// Save はジョブを jobs テーブルに保存する。AnalysisID が空のときは NULL を挿入する。
 func (r *JobRepo) Save(ctx context.Context, j *domain.Job) error {
-	// TODO: implement
+	var analysisID sql.NullString
+	if j.AnalysisID != "" {
+		analysisID = sql.NullString{String: string(j.AnalysisID), Valid: true}
+	}
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO jobs (id, analysis_id, status, error, created_at, updated_at,
+		 pr_owner, pr_repo, pr_number, pr_title, pr_base_ref, pr_head_ref, pr_head_sha)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		string(j.ID), analysisID, string(j.Status), j.Error,
+		j.CreatedAt.UTC(), j.UpdatedAt.UTC(),
+		j.PR.Owner, j.PR.Repo, j.PR.Number,
+		j.PR.Title, j.PR.BaseRef, j.PR.HeadRef, j.PR.HeadSHA,
+	)
+	if err != nil {
+		return fmt.Errorf("insert job: %w", err)
+	}
 	return nil
 }
 
+// UpdateStatus はジョブのステータスとエラーメッセージを更新する。
 func (r *JobRepo) UpdateStatus(ctx context.Context, id domain.JobID, status domain.JobStatus, errMsg string) error {
-	// TODO: implement
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE jobs SET status=?, error=?, updated_at=? WHERE id=?`,
+		string(status), errMsg, time.Now().UTC(), string(id),
+	)
+	if err != nil {
+		return fmt.Errorf("update job status: %w", err)
+	}
 	return nil
 }
 
+// UpdateAnalysisID はジョブの analysis_id を更新する。ワーカーが解析完了時に呼ぶ。
+// このメソッドは domain.JobRepository インターフェースには含まれない（ワーカー専用）。
+func (r *JobRepo) UpdateAnalysisID(ctx context.Context, id domain.JobID, analysisID domain.AnalysisID) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE jobs SET analysis_id=?, updated_at=? WHERE id=?`,
+		string(analysisID), time.Now().UTC(), string(id),
+	)
+	if err != nil {
+		return fmt.Errorf("update job analysis_id: %w", err)
+	}
+	return nil
+}
+
+// FindByID は ID でジョブを返す。存在しない場合は (nil, nil) を返す。
 func (r *JobRepo) FindByID(ctx context.Context, id domain.JobID) (*domain.Job, error) {
-	// TODO: implement
-	return nil, nil
+	var (
+		analysisID sql.NullString
+		status     string
+		errMsg     sql.NullString
+		createdAt  time.Time
+		updatedAt  time.Time
+		prOwner    string
+		prRepo     string
+		prNumber   int
+		prTitle    string
+		prBaseRef  string
+		prHeadRef  string
+		prHeadSHA  string
+	)
+	err := r.db.QueryRowContext(ctx,
+		`SELECT analysis_id, status, error, created_at, updated_at,
+		 pr_owner, pr_repo, pr_number, pr_title, pr_base_ref, pr_head_ref, pr_head_sha
+		 FROM jobs WHERE id = ?`,
+		string(id),
+	).Scan(
+		&analysisID, &status, &errMsg, &createdAt, &updatedAt,
+		&prOwner, &prRepo, &prNumber, &prTitle, &prBaseRef, &prHeadRef, &prHeadSHA,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query job: %w", err)
+	}
+
+	j := &domain.Job{
+		ID:        id,
+		Status:    domain.JobStatus(status),
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+		PR: domain.PRInfo{
+			Owner:   prOwner,
+			Repo:    prRepo,
+			Number:  prNumber,
+			Title:   prTitle,
+			BaseRef: prBaseRef,
+			HeadRef: prHeadRef,
+			HeadSHA: prHeadSHA,
+		},
+	}
+	if analysisID.Valid {
+		j.AnalysisID = domain.AnalysisID(analysisID.String)
+	}
+	if errMsg.Valid {
+		j.Error = errMsg.String
+	}
+	return j, nil
 }

--- a/backend/internal/infra/store/job_repo_test.go
+++ b/backend/internal/infra/store/job_repo_test.go
@@ -1,0 +1,204 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
+)
+
+func makeJob(id string, status domain.JobStatus) *domain.Job {
+	now := time.Now().UTC().Truncate(time.Second)
+	return &domain.Job{
+		ID:     domain.JobID(id),
+		Status: status,
+		PR: domain.PRInfo{
+			Owner:   "owner",
+			Repo:    "repo",
+			Number:  42,
+			Title:   "fix: bug",
+			BaseRef: "main",
+			HeadRef: "fix-branch",
+			HeadSHA: "abc123",
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+func TestJobRepo_SaveAndFindByID(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	repo := NewJobRepo(db)
+	ctx := context.Background()
+
+	j := makeJob("job-1", domain.JobStatusPending)
+	if err := repo.Save(ctx, j); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := repo.FindByID(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("FindByID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil job")
+	}
+	if got.ID != j.ID {
+		t.Errorf("ID mismatch: got %s", got.ID)
+	}
+	if got.Status != domain.JobStatusPending {
+		t.Errorf("Status mismatch: got %s", got.Status)
+	}
+	if got.AnalysisID != "" {
+		t.Errorf("expected empty AnalysisID, got %s", got.AnalysisID)
+	}
+	if got.PR.Owner != "owner" || got.PR.Repo != "repo" || got.PR.Number != 42 {
+		t.Errorf("PR mismatch: got %+v", got.PR)
+	}
+	if got.PR.Title != "fix: bug" || got.PR.HeadSHA != "abc123" {
+		t.Errorf("PR detail mismatch: got %+v", got.PR)
+	}
+}
+
+func TestJobRepo_FindByID_NotFound(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	repo := NewJobRepo(db)
+	got, err := repo.FindByID(context.Background(), "nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}
+
+func TestJobRepo_UpdateStatus(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	repo := NewJobRepo(db)
+	ctx := context.Background()
+
+	j := makeJob("job-2", domain.JobStatusPending)
+	if err := repo.Save(ctx, j); err != nil {
+		t.Fatal(err)
+	}
+
+	prevUpdatedAt := j.UpdatedAt
+	time.Sleep(10 * time.Millisecond)
+
+	if err := repo.UpdateStatus(ctx, j.ID, domain.JobStatusRunning, ""); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+
+	got, err := repo.FindByID(ctx, j.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != domain.JobStatusRunning {
+		t.Errorf("expected running, got %s", got.Status)
+	}
+	if !got.UpdatedAt.After(prevUpdatedAt) {
+		t.Errorf("updated_at did not advance")
+	}
+}
+
+func TestJobRepo_UpdateStatus_WithError(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	repo := NewJobRepo(db)
+	ctx := context.Background()
+
+	j := makeJob("job-3", domain.JobStatusRunning)
+	if err := repo.Save(ctx, j); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repo.UpdateStatus(ctx, j.ID, domain.JobStatusError, "something went wrong"); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+
+	got, err := repo.FindByID(ctx, j.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != domain.JobStatusError {
+		t.Errorf("expected error status, got %s", got.Status)
+	}
+	if got.Error != "something went wrong" {
+		t.Errorf("expected error message, got %q", got.Error)
+	}
+}
+
+func TestJobRepo_UpdateAnalysisID(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	repo := NewJobRepo(db)
+	ctx := context.Background()
+
+	j := makeJob("job-4", domain.JobStatusRunning)
+	if err := repo.Save(ctx, j); err != nil {
+		t.Fatal(err)
+	}
+
+	analysisID := domain.AnalysisID("analysis-xyz")
+	if err := repo.UpdateAnalysisID(ctx, j.ID, analysisID); err != nil {
+		t.Fatalf("UpdateAnalysisID: %v", err)
+	}
+
+	got, err := repo.FindByID(ctx, j.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AnalysisID != analysisID {
+		t.Errorf("expected analysisID=%s, got %s", analysisID, got.AnalysisID)
+	}
+}
+
+func TestJobRepo_SaveWithAnalysisID(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	repo := NewJobRepo(db)
+	ctx := context.Background()
+
+	j := makeJob("job-5", domain.JobStatusDone)
+	j.AnalysisID = "analysis-abc"
+
+	if err := repo.Save(ctx, j); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := repo.FindByID(ctx, j.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AnalysisID != "analysis-abc" {
+		t.Errorf("expected analysis-abc, got %s", got.AnalysisID)
+	}
+}

--- a/backend/internal/infra/store/job_repo_test.go
+++ b/backend/internal/infra/store/job_repo_test.go
@@ -32,7 +32,7 @@ func TestJobRepo_SaveAndFindByID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	repo := NewJobRepo(db)
 	ctx := context.Background()
@@ -71,7 +71,7 @@ func TestJobRepo_FindByID_NotFound(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	repo := NewJobRepo(db)
 	got, err := repo.FindByID(context.Background(), "nonexistent")
@@ -88,7 +88,7 @@ func TestJobRepo_UpdateStatus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	repo := NewJobRepo(db)
 	ctx := context.Background()
@@ -122,7 +122,7 @@ func TestJobRepo_UpdateStatus_WithError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	repo := NewJobRepo(db)
 	ctx := context.Background()
@@ -153,7 +153,7 @@ func TestJobRepo_UpdateAnalysisID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	repo := NewJobRepo(db)
 	ctx := context.Background()
@@ -182,7 +182,7 @@ func TestJobRepo_SaveWithAnalysisID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	repo := NewJobRepo(db)
 	ctx := context.Background()

--- a/backend/internal/infra/store/schema.sql
+++ b/backend/internal/infra/store/schema.sql
@@ -11,11 +11,18 @@ CREATE TABLE IF NOT EXISTS analyses (
 -- jobs テーブル
 CREATE TABLE IF NOT EXISTS jobs (
     id          TEXT PRIMARY KEY,
-    analysis_id TEXT NOT NULL,
+    analysis_id TEXT,
     status      TEXT NOT NULL,
     error       TEXT,
     created_at  DATETIME NOT NULL,
-    updated_at  DATETIME NOT NULL
+    updated_at  DATETIME NOT NULL,
+    pr_owner    TEXT NOT NULL DEFAULT '',
+    pr_repo     TEXT NOT NULL DEFAULT '',
+    pr_number   INTEGER NOT NULL DEFAULT 0,
+    pr_title    TEXT NOT NULL DEFAULT '',
+    pr_base_ref TEXT NOT NULL DEFAULT '',
+    pr_head_ref TEXT NOT NULL DEFAULT '',
+    pr_head_sha TEXT NOT NULL DEFAULT ''
 );
 
 -- sessions テーブル（OAuth セッション・アクセストークン）

--- a/backend/internal/usecase/analyze_pr.go
+++ b/backend/internal/usecase/analyze_pr.go
@@ -2,20 +2,83 @@ package usecase
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"time"
 
 	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
 )
 
-// AnalyzePRUseCase はPR解析ユースケースの依存インターフェース
-type AnalyzePRUseCase struct {
-	// TODO: analyzer, cluster, github, analysisRepo, jobRepo を注入
+// JobEnqueuer はジョブをキューに追加するインターフェース。infra/job.Queue が実装する。
+type JobEnqueuer interface {
+	Enqueue(jobID domain.JobID, token string)
 }
 
-// Execute はPR解析ジョブを開始し、JobIDを返す
-func (uc *AnalyzePRUseCase) Execute(ctx context.Context, pr domain.PRInfo) (domain.JobID, error) {
-	// TODO: implement
-	// 1. キャッシュ確認（同一PRの既存結果があれば即返す）
-	// 2. Jobエンティティ作成・保存
-	// 3. ジョブキューに enqueue
-	return "", nil
+// AnalyzePRUseCase はPR解析ジョブを開始するユースケース。
+type AnalyzePRUseCase struct {
+	analyses domain.AnalysisRepository
+	jobs     domain.JobRepository
+	queue    JobEnqueuer
+	now      func() time.Time
+	newID    func() string
+}
+
+// NewAnalyzePRUseCase は AnalyzePRUseCase を返す。
+func NewAnalyzePRUseCase(analyses domain.AnalysisRepository, jobs domain.JobRepository, queue JobEnqueuer) *AnalyzePRUseCase {
+	return &AnalyzePRUseCase{
+		analyses: analyses,
+		jobs:     jobs,
+		queue:    queue,
+		now:      time.Now,
+		newID:    randomID,
+	}
+}
+
+// Execute はPR解析ジョブを開始し、JobIDを返す。
+// キャッシュ (同一 PR の既存解析) があれば done ジョブを即返し、enqueue しない。
+func (uc *AnalyzePRUseCase) Execute(ctx context.Context, token string, pr domain.PRInfo) (domain.JobID, error) {
+	cached, err := uc.analyses.FindByPR(ctx, pr)
+	if err != nil {
+		return "", fmt.Errorf("find cached analysis: %w", err)
+	}
+
+	now := uc.now().UTC()
+	jobID := domain.JobID(uc.newID())
+
+	if cached != nil {
+		j := &domain.Job{
+			ID:         jobID,
+			AnalysisID: cached.ID,
+			PR:         pr,
+			Status:     domain.JobStatusDone,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		}
+		if err := uc.jobs.Save(ctx, j); err != nil {
+			return "", fmt.Errorf("save cached job: %w", err)
+		}
+		return jobID, nil
+	}
+
+	j := &domain.Job{
+		ID:        jobID,
+		PR:        pr,
+		Status:    domain.JobStatusPending,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := uc.jobs.Save(ctx, j); err != nil {
+		return "", fmt.Errorf("save job: %w", err)
+	}
+	uc.queue.Enqueue(jobID, token)
+	return jobID, nil
+}
+
+func randomID() string {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		panic(fmt.Sprintf("randomID: %v", err))
+	}
+	return base64.RawURLEncoding.EncodeToString(buf)
 }

--- a/backend/internal/usecase/analyze_pr_test.go
+++ b/backend/internal/usecase/analyze_pr_test.go
@@ -1,0 +1,170 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
+)
+
+// --- fakes ---
+
+type fakeAnalysisRepo struct {
+	byID map[domain.AnalysisID]*domain.Analysis
+	byPR *domain.Analysis // FindByPR が返す固定値
+	err  error
+}
+
+func (r *fakeAnalysisRepo) Save(_ context.Context, a *domain.Analysis) error {
+	if r.err != nil {
+		return r.err
+	}
+	if r.byID == nil {
+		r.byID = make(map[domain.AnalysisID]*domain.Analysis)
+	}
+	r.byID[a.ID] = a
+	return nil
+}
+
+func (r *fakeAnalysisRepo) FindByID(_ context.Context, id domain.AnalysisID) (*domain.Analysis, error) {
+	return r.byID[id], r.err
+}
+
+func (r *fakeAnalysisRepo) FindByPR(_ context.Context, _ domain.PRInfo) (*domain.Analysis, error) {
+	return r.byPR, r.err
+}
+
+type fakeJobRepo struct {
+	saved []*domain.Job
+	err   error
+}
+
+func (r *fakeJobRepo) Save(_ context.Context, j *domain.Job) error {
+	if r.err != nil {
+		return r.err
+	}
+	r.saved = append(r.saved, j)
+	return nil
+}
+
+func (r *fakeJobRepo) UpdateStatus(_ context.Context, _ domain.JobID, _ domain.JobStatus, _ string) error {
+	return r.err
+}
+
+func (r *fakeJobRepo) FindByID(_ context.Context, id domain.JobID) (*domain.Job, error) {
+	for _, j := range r.saved {
+		if j.ID == id {
+			return j, nil
+		}
+	}
+	return nil, r.err
+}
+
+type fakeEnqueuer struct {
+	calls []struct {
+		jobID domain.JobID
+		token string
+	}
+}
+
+func (e *fakeEnqueuer) Enqueue(jobID domain.JobID, token string) {
+	e.calls = append(e.calls, struct {
+		jobID domain.JobID
+		token string
+	}{jobID, token})
+}
+
+// --- tests ---
+
+func TestAnalyzePR_CacheMiss_Enqueue(t *testing.T) {
+	analyses := &fakeAnalysisRepo{byPR: nil}
+	jobs := &fakeJobRepo{}
+	enqueuer := &fakeEnqueuer{}
+
+	uc := NewAnalyzePRUseCase(analyses, jobs, enqueuer)
+	pr := domain.PRInfo{Owner: "o", Repo: "r", Number: 1}
+
+	jobID, err := uc.Execute(context.Background(), "token-xxx", pr)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if jobID == "" {
+		t.Error("expected non-empty jobID")
+	}
+	if len(jobs.saved) != 1 {
+		t.Fatalf("expected 1 saved job, got %d", len(jobs.saved))
+	}
+	if jobs.saved[0].Status != domain.JobStatusPending {
+		t.Errorf("expected pending, got %s", jobs.saved[0].Status)
+	}
+	if len(enqueuer.calls) != 1 {
+		t.Fatalf("expected 1 enqueue call, got %d", len(enqueuer.calls))
+	}
+	if enqueuer.calls[0].token != "token-xxx" {
+		t.Errorf("unexpected token: %s", enqueuer.calls[0].token)
+	}
+}
+
+func TestAnalyzePR_CacheHit_NoEnqueue(t *testing.T) {
+	cachedAnalysis := &domain.Analysis{
+		ID: "cached-analysis",
+		PR: domain.PRInfo{Owner: "o", Repo: "r", Number: 1},
+	}
+	analyses := &fakeAnalysisRepo{byPR: cachedAnalysis}
+	jobs := &fakeJobRepo{}
+	enqueuer := &fakeEnqueuer{}
+
+	uc := NewAnalyzePRUseCase(analyses, jobs, enqueuer)
+	pr := domain.PRInfo{Owner: "o", Repo: "r", Number: 1}
+
+	jobID, err := uc.Execute(context.Background(), "token-xxx", pr)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if jobID == "" {
+		t.Error("expected non-empty jobID")
+	}
+	if len(jobs.saved) != 1 {
+		t.Fatalf("expected 1 saved job, got %d", len(jobs.saved))
+	}
+	if jobs.saved[0].Status != domain.JobStatusDone {
+		t.Errorf("expected done, got %s", jobs.saved[0].Status)
+	}
+	if jobs.saved[0].AnalysisID != "cached-analysis" {
+		t.Errorf("expected cached-analysis, got %s", jobs.saved[0].AnalysisID)
+	}
+	if len(enqueuer.calls) != 0 {
+		t.Errorf("expected no enqueue calls, got %d", len(enqueuer.calls))
+	}
+}
+
+func TestAnalyzePR_RepoError_Propagated(t *testing.T) {
+	sentinel := errors.New("db down")
+	analyses := &fakeAnalysisRepo{err: sentinel}
+	jobs := &fakeJobRepo{}
+	enqueuer := &fakeEnqueuer{}
+
+	uc := NewAnalyzePRUseCase(analyses, jobs, enqueuer)
+	_, err := uc.Execute(context.Background(), "t", domain.PRInfo{Owner: "o", Repo: "r", Number: 1})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected sentinel error, got %v", err)
+	}
+}
+
+func TestAnalyzePR_IDsAreUnique(t *testing.T) {
+	analyses := &fakeAnalysisRepo{}
+	jobs := &fakeJobRepo{}
+	enqueuer := &fakeEnqueuer{}
+
+	uc := NewAnalyzePRUseCase(analyses, jobs, enqueuer)
+	uc.now = func() time.Time { return time.Now() }
+
+	pr := domain.PRInfo{Owner: "o", Repo: "r", Number: 1}
+	id1, _ := uc.Execute(context.Background(), "t", pr)
+	id2, _ := uc.Execute(context.Background(), "t", pr)
+	if id1 == id2 {
+		t.Error("expected unique IDs")
+	}
+}

--- a/backend/internal/usecase/get_analysis.go
+++ b/backend/internal/usecase/get_analysis.go
@@ -2,23 +2,58 @@ package usecase
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
 )
 
-// GetAnalysisUseCase は解析結果・ジョブ状態の取得ユースケース
+// ErrJobNotFound はジョブが存在しない場合のエラー。
+var ErrJobNotFound = errors.New("job not found")
+
+// ErrJobNotReady はジョブがまだ完了していない場合のエラー。
+var ErrJobNotReady = errors.New("job not ready")
+
+// GetAnalysisUseCase は解析結果・ジョブ状態の取得ユースケース。
 type GetAnalysisUseCase struct {
-	// TODO: analysisRepo, jobRepo を注入
+	analyses domain.AnalysisRepository
+	jobs     domain.JobRepository
 }
 
-// GetJob はジョブの状態を返す
+// NewGetAnalysisUseCase は GetAnalysisUseCase を返す。
+func NewGetAnalysisUseCase(analyses domain.AnalysisRepository, jobs domain.JobRepository) *GetAnalysisUseCase {
+	return &GetAnalysisUseCase{analyses: analyses, jobs: jobs}
+}
+
+// GetJob はジョブの状態を返す。存在しない場合は (nil, nil) を返す。
 func (uc *GetAnalysisUseCase) GetJob(ctx context.Context, id domain.JobID) (*domain.Job, error) {
-	// TODO: implement
-	return nil, nil
+	j, err := uc.jobs.FindByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("find job: %w", err)
+	}
+	return j, nil
 }
 
-// GetAnalysis は解析結果を返す
-func (uc *GetAnalysisUseCase) GetAnalysis(ctx context.Context, id domain.AnalysisID) (*domain.Analysis, error) {
-	// TODO: implement
-	return nil, nil
+// GetGraph はジョブに紐づく解析結果を返す。
+// ジョブが存在しない場合は ErrJobNotFound、まだ完了していない場合は ErrJobNotReady を返す。
+func (uc *GetAnalysisUseCase) GetGraph(ctx context.Context, id domain.JobID) (*domain.Analysis, error) {
+	j, err := uc.jobs.FindByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("find job: %w", err)
+	}
+	if j == nil {
+		return nil, ErrJobNotFound
+	}
+	if j.Status != domain.JobStatusDone || j.AnalysisID == "" {
+		return nil, ErrJobNotReady
+	}
+
+	a, err := uc.analyses.FindByID(ctx, j.AnalysisID)
+	if err != nil {
+		return nil, fmt.Errorf("find analysis: %w", err)
+	}
+	if a == nil {
+		return nil, fmt.Errorf("data integrity error: job %s is done but analysis %s not found", id, j.AnalysisID)
+	}
+	return a, nil
 }

--- a/backend/internal/usecase/get_analysis_test.go
+++ b/backend/internal/usecase/get_analysis_test.go
@@ -1,0 +1,160 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
+)
+
+type fakeGetJobRepo struct {
+	jobs map[domain.JobID]*domain.Job
+	err  error
+}
+
+func (r *fakeGetJobRepo) Save(_ context.Context, j *domain.Job) error {
+	if r.jobs == nil {
+		r.jobs = make(map[domain.JobID]*domain.Job)
+	}
+	r.jobs[j.ID] = j
+	return nil
+}
+
+func (r *fakeGetJobRepo) UpdateStatus(_ context.Context, _ domain.JobID, _ domain.JobStatus, _ string) error {
+	return r.err
+}
+
+func (r *fakeGetJobRepo) FindByID(_ context.Context, id domain.JobID) (*domain.Job, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.jobs[id], nil
+}
+
+type fakeGetAnalysisRepo struct {
+	analyses map[domain.AnalysisID]*domain.Analysis
+	err      error
+}
+
+func (r *fakeGetAnalysisRepo) Save(_ context.Context, a *domain.Analysis) error {
+	if r.analyses == nil {
+		r.analyses = make(map[domain.AnalysisID]*domain.Analysis)
+	}
+	r.analyses[a.ID] = a
+	return nil
+}
+
+func (r *fakeGetAnalysisRepo) FindByID(_ context.Context, id domain.AnalysisID) (*domain.Analysis, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.analyses[id], nil
+}
+
+func (r *fakeGetAnalysisRepo) FindByPR(_ context.Context, _ domain.PRInfo) (*domain.Analysis, error) {
+	return nil, r.err
+}
+
+func TestGetGraph_NotFound(t *testing.T) {
+	jobs := &fakeGetJobRepo{jobs: make(map[domain.JobID]*domain.Job)}
+	analyses := &fakeGetAnalysisRepo{analyses: make(map[domain.AnalysisID]*domain.Analysis)}
+	uc := NewGetAnalysisUseCase(analyses, jobs)
+
+	_, err := uc.GetGraph(context.Background(), "nonexistent")
+	if !errors.Is(err, ErrJobNotFound) {
+		t.Errorf("expected ErrJobNotFound, got %v", err)
+	}
+}
+
+func TestGetGraph_NotReady_Pending(t *testing.T) {
+	jobs := &fakeGetJobRepo{jobs: map[domain.JobID]*domain.Job{
+		"j1": {ID: "j1", Status: domain.JobStatusPending},
+	}}
+	analyses := &fakeGetAnalysisRepo{analyses: make(map[domain.AnalysisID]*domain.Analysis)}
+	uc := NewGetAnalysisUseCase(analyses, jobs)
+
+	_, err := uc.GetGraph(context.Background(), "j1")
+	if !errors.Is(err, ErrJobNotReady) {
+		t.Errorf("expected ErrJobNotReady, got %v", err)
+	}
+}
+
+func TestGetGraph_NotReady_DoneButNoAnalysisID(t *testing.T) {
+	jobs := &fakeGetJobRepo{jobs: map[domain.JobID]*domain.Job{
+		"j2": {ID: "j2", Status: domain.JobStatusDone, AnalysisID: ""},
+	}}
+	analyses := &fakeGetAnalysisRepo{analyses: make(map[domain.AnalysisID]*domain.Analysis)}
+	uc := NewGetAnalysisUseCase(analyses, jobs)
+
+	_, err := uc.GetGraph(context.Background(), "j2")
+	if !errors.Is(err, ErrJobNotReady) {
+		t.Errorf("expected ErrJobNotReady, got %v", err)
+	}
+}
+
+func TestGetGraph_Success(t *testing.T) {
+	analysis := &domain.Analysis{
+		ID:        "a1",
+		PR:        domain.PRInfo{Owner: "o", Repo: "r", Number: 1},
+		Result:    &domain.ClusterResult{},
+		CreatedAt: time.Now(),
+	}
+	jobs := &fakeGetJobRepo{jobs: map[domain.JobID]*domain.Job{
+		"j3": {ID: "j3", Status: domain.JobStatusDone, AnalysisID: "a1"},
+	}}
+	analyses := &fakeGetAnalysisRepo{analyses: map[domain.AnalysisID]*domain.Analysis{
+		"a1": analysis,
+	}}
+	uc := NewGetAnalysisUseCase(analyses, jobs)
+
+	got, err := uc.GetGraph(context.Background(), "j3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || got.ID != "a1" {
+		t.Errorf("unexpected analysis: %+v", got)
+	}
+}
+
+func TestGetGraph_IntegrityError(t *testing.T) {
+	jobs := &fakeGetJobRepo{jobs: map[domain.JobID]*domain.Job{
+		"j4": {ID: "j4", Status: domain.JobStatusDone, AnalysisID: "missing-analysis"},
+	}}
+	analyses := &fakeGetAnalysisRepo{analyses: make(map[domain.AnalysisID]*domain.Analysis)}
+	uc := NewGetAnalysisUseCase(analyses, jobs)
+
+	_, err := uc.GetGraph(context.Background(), "j4")
+	if err == nil {
+		t.Error("expected error for missing analysis, got nil")
+	}
+}
+
+func TestGetJob_Delegates(t *testing.T) {
+	jobs := &fakeGetJobRepo{jobs: map[domain.JobID]*domain.Job{
+		"j5": {ID: "j5", Status: domain.JobStatusRunning},
+	}}
+	analyses := &fakeGetAnalysisRepo{}
+	uc := NewGetAnalysisUseCase(analyses, jobs)
+
+	got, err := uc.GetJob(context.Background(), "j5")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || got.ID != "j5" {
+		t.Errorf("unexpected job: %+v", got)
+	}
+}
+
+func TestGetJob_RepoError(t *testing.T) {
+	sentinel := errors.New("db error")
+	jobs := &fakeGetJobRepo{err: sentinel}
+	analyses := &fakeGetAnalysisRepo{}
+	uc := NewGetAnalysisUseCase(analyses, jobs)
+
+	_, err := uc.GetJob(context.Background(), "any")
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected sentinel error, got %v", err)
+	}
+}


### PR DESCRIPTION
## 概要

issue #7「REST API エンドポイント実装」を実装。フロントエンドが PR 解析結果を取得できる 3 本の API エンドポイントをバックエンドに追加した。

## 実装内容

### API エンドポイント（Echo v4、RequireAuth 済み）
- `POST /api/analyze` — PR URL を受け取りジョブを開始。キャッシュヒット時は即 `done` で返す
- `GET /api/jobs/:id` — ジョブのステータスをポーリング用に返す
- `GET /api/graph/:jobId` — 完了ジョブのグラフデータ（クラスタ + ノード + エッジ）を返す

### SQLite リポジトリ
- `AnalysisRepo` — 解析結果を JSON シリアライズして保存。`FindByPR(owner, repo, number)` でキャッシュ検索
- `JobRepo` — ジョブ状態と PR 情報を保存。`UpdateAnalysisID` を追加（ワーカー専用）
- `schema.sql` 拡張 — `jobs` テーブルに PR 情報カラムを追加、`analysis_id` を NULL 許容に変更

### ユースケース
- `AnalyzePRUseCase.Execute(ctx, token, pr)` — キャッシュ確認 → ミスなら enqueue
- `GetAnalysisUseCase.GetJob` / `GetGraph` — `ErrJobNotFound`(404) / `ErrJobNotReady`(409) のセンチネル定義

### ジョブキュー + ワーカー
- `Queue` — buffered channel (デフォルト 32) の in-process キュー
- `Worker` — goroutine パイプライン: GitHub PR 取得 → shallow clone → go/packages → callgraph → Louvain → SQLite 保存
- トークンはキューペイロード内のみ（永続化なし）

### main.go
- graceful shutdown: `signal.NotifyContext` + `errgroup`

### バグ修正（E2E テスト中に発見・修正）
- `GIT_TERMINAL_PROMPT=0` で git clone 時の認証プロンプト抑止
- `http.extraheader` が効かなかったため URL 埋め込みトークン方式に変更
- モノレポ対応: `go.mod` を自動検出してサブディレクトリからパッケージをロード
- `IdentifyChangedPackages` の基点をリポジトリルートに修正（`backend/backend/...` の二重パス問題）

## テスト

- `infra/store`: `:memory:` SQLite 結合テスト（round-trip / `pr_*` カラム / UpdateStatus / FindByPR）
- `usecase`: 手書きフェイクによる単体テスト（キャッシュ hit/miss / エラー伝播 / GetGraph 4ケース）
- `infra/job`: ワーカー単体テスト（happy path / PR 取得失敗 / ctx cancel / queue close）
- `api`: httptest + Echo の handler テスト（parsePRURL テーブル駆動 / 各エラーコード）

```
ok  github.com/s-sh1m0/u-22_procon/backend/internal/api
ok  github.com/s-sh1m0/u-22_procon/backend/internal/infra/analyzer
ok  github.com/s-sh1m0/u-22_procon/backend/internal/infra/cluster
ok  github.com/s-sh1m0/u-22_procon/backend/internal/infra/github
ok  github.com/s-sh1m0/u-22_procon/backend/internal/infra/job
ok  github.com/s-sh1m0/u-22_procon/backend/internal/infra/store
ok  github.com/s-sh1m0/u-22_procon/backend/internal/usecase
```

## E2E 動作確認

PR #35 (Louvain クラスタリング実装) を実際に解析:
- `POST /api/analyze` → `200 pending`
- ポーリング後 → `done` (約80秒)
- `GET /api/graph/:jobId` → 10,652 ノード・458,218 エッジ・2,689 クラスタ

全エラーケース確認: 401 / 400 / 404 / 409 / キャッシュヒット即 done

## 既存ローカル DB の移行

`jobs` テーブルスキーマを変更しているため、既存 DB は削除が必要:
```bash
docker run --rm -v $(pwd)/data:/data alpine rm -f /data/reviewarena.db
```

## 既知制約（別 issue で対応予定）

- 再起動時に pending ジョブが消える → #12
- キャッシュキーが `(owner, repo, number)` のみ、force-push に追従しない → #13
- 外部依存パッケージがグラフに含まれる（フィルタリングは別途検討）

Closes #7