### PR TITLE
feat: PR URL 入力・分析トリガー UI (#9)

### DIFF
--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Card({
+  className,
+  size = 'default',
+  ...props
+}: React.ComponentProps<'div'> & { size?: 'default' | 'sm' }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        'group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        'group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        'font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn('col-start-2 row-span-2 row-start-1 self-start justify-self-end', className)}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn('px-4 group-data-[size=sm]/card:px-3', className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        'flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent }

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        'h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/frontend/src/hooks/useAnalysis.ts
+++ b/frontend/src/hooks/useAnalysis.ts
@@ -1,1 +1,14 @@
-// TODO: TanStack Query で POST 解析リクエスト送信・結果取得
+import { useMutation } from '@tanstack/react-query'
+import { apiFetch } from '@/lib/api'
+import type { JobResponse } from '@/types/api'
+
+export function useAnalyzeMutation() {
+  return useMutation({
+    mutationFn: (prUrl: string) =>
+      apiFetch<JobResponse>('/api/analyze', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pr_url: prUrl }),
+      }),
+  })
+}

--- a/frontend/src/hooks/useJobStatus.ts
+++ b/frontend/src/hooks/useJobStatus.ts
@@ -1,1 +1,16 @@
-// TODO: TanStack Query で GET /api/jobs/:id をポーリング
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from '@/lib/api'
+import type { JobResponse } from '@/types/api'
+
+export function useJobStatus(jobId: string) {
+  return useQuery<JobResponse>({
+    queryKey: ['jobs', jobId],
+    queryFn: () => apiFetch<JobResponse>(`/api/jobs/${jobId}`),
+    refetchInterval: (query) => {
+      const status = query.state.data?.status
+      if (status === 'done' || status === 'error') return false
+      return 1500
+    },
+    enabled: !!jobId,
+  })
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8,13 +8,24 @@ export class ApiError extends Error {
   }
 }
 
+async function extractErrorMessage(res: Response): Promise<string> {
+  try {
+    const json = (await res.json()) as { message?: string }
+    if (json.message) return json.message
+  } catch {
+    // fall through
+  }
+  return `${res.status} ${res.statusText}`
+}
+
 export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(path, {
     ...init,
     headers: { Accept: 'application/json', ...init?.headers },
   })
   if (!res.ok) {
-    throw new ApiError(res.status, `${res.status} ${res.statusText}`)
+    const msg = await extractErrorMessage(res)
+    throw new ApiError(res.status, msg)
   }
   return res.json() as Promise<T>
 }
@@ -25,6 +36,7 @@ export async function apiFetchVoid(path: string, init?: RequestInit): Promise<vo
     headers: { Accept: 'application/json', ...init?.headers },
   })
   if (!res.ok) {
-    throw new ApiError(res.status, `${res.status} ${res.statusText}`)
+    const msg = await extractErrorMessage(res)
+    throw new ApiError(res.status, msg)
   }
 }

--- a/frontend/src/lib/prUrl.ts
+++ b/frontend/src/lib/prUrl.ts
@@ -1,0 +1,27 @@
+export type ParsedPrUrl = {
+  owner: string
+  repo: string
+  number: number
+}
+
+export function parsePrUrl(raw: string): ParsedPrUrl | null {
+  let u: URL
+  try {
+    u = new URL(raw.trim())
+  } catch {
+    return null
+  }
+  if (u.protocol !== 'https:' && u.protocol !== 'http:') return null
+  if (u.hostname !== 'github.com') return null
+
+  const parts = u.pathname.replace(/^\//, '').split('/')
+  if (parts.length !== 4 || parts[2] !== 'pull') return null
+
+  const [owner, repo, , numberStr] = parts
+  if (!owner || !repo) return null
+
+  const number = parseInt(numberStr, 10)
+  if (!Number.isInteger(number) || number <= 0) return null
+
+  return { owner, repo, number }
+}

--- a/frontend/src/pages/Analysis.tsx
+++ b/frontend/src/pages/Analysis.tsx
@@ -1,4 +1,231 @@
-// TODO: グラフ可視化メインページ（クラスタ一覧 + グラフ + diff）
+import { useEffect, useState } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import { useJobStatus } from '@/hooks/useJobStatus'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+const STEPS = [
+  'リポジトリのクローン',
+  '依存グラフの構築 (AST 解析)',
+  '差分との突き合わせ',
+  'クラスタ分類（4-way）',
+  '可視化の生成',
+] as const
+
+const STEP_DURATIONS_MS = [2000, 4000, 6000, 9000]
+
+type StepStatus = 'done' | 'active' | 'pending'
+
+function useStepProgress(jobStatus: string | undefined): StepStatus[] {
+  const [elapsed, setElapsed] = useState(0)
+
+  useEffect(() => {
+    if (jobStatus !== 'pending' && jobStatus !== 'running') return
+    const start = Date.now()
+    const id = setInterval(() => setElapsed(Date.now() - start), 500)
+    return () => clearInterval(id)
+  }, [jobStatus])
+
+  if (jobStatus === 'done' || jobStatus === 'error') {
+    return STEPS.map(() => (jobStatus === 'done' ? 'done' : 'pending'))
+  }
+
+  return STEPS.map((_, i) => {
+    if (i < STEPS.length - 1 && elapsed > STEP_DURATIONS_MS[i]) return 'done'
+    const prevDone = i === 0 || elapsed > STEP_DURATIONS_MS[i - 1]
+    if (prevDone) return 'active'
+    return 'pending'
+  })
+}
+
+function isNoPackagesError(msg: string | undefined) {
+  return msg?.includes('no Go packages found') || msg?.includes('ErrNoPackages')
+}
+
 export default function Analysis() {
-  return <div>Analysis</div>
+  const { jobId } = useParams<{ jobId: string }>()
+  const { data: job, isLoading } = useJobStatus(jobId ?? '')
+  const stepStatuses = useStepProgress(job?.status)
+
+  if (isLoading || !job) {
+    return (
+      <div className="flex min-h-svh items-center justify-center bg-[#fafaf9]">
+        <Spinner label="ジョブを読み込み中…" />
+      </div>
+    )
+  }
+
+  if (job.status === 'error') {
+    const isNonGo = isNoPackagesError(job.error)
+    return (
+      <div className="flex min-h-svh items-center justify-center bg-[#fafaf9]">
+        <Card className="w-full max-w-md border-red-200">
+          <CardContent className="pt-6 space-y-3">
+            <div className="flex items-center gap-2 text-red-600 font-semibold">
+              <ErrorIcon />
+              <span>解析に失敗しました</span>
+            </div>
+            <p className="text-sm text-stone-600">
+              {isNonGo
+                ? 'Go コードを含む PR ではありません。Go リポジトリの PR URL を指定してください。'
+                : job.error}
+            </p>
+            <Button asChild variant="outline" size="sm" className="mt-2">
+              <Link to="/">別の PR を試す</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  if (job.status === 'done') {
+    return (
+      <div className="flex min-h-svh items-center justify-center bg-[#fafaf9]">
+        <Card className="w-full max-w-md border-teal-200">
+          <CardContent className="pt-6 space-y-3">
+            <div className="flex items-center gap-2 text-teal-600 font-semibold">
+              <CheckCircleIcon />
+              <span>解析が完了しました</span>
+            </div>
+            <p className="text-sm text-stone-500">グラフビューは次のリリースで実装予定です。</p>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-svh items-center justify-center bg-[#fafaf9]">
+      <div className="w-full max-w-sm space-y-5 px-4">
+        <div className="flex items-center gap-4">
+          <div className="flex size-11 items-center justify-center rounded-xl bg-teal-50 text-teal-600">
+            <SpinnerIcon />
+          </div>
+          <div>
+            <p className="text-lg font-semibold text-stone-900">解析中…</p>
+            <p className="text-sm text-stone-400">依存関係を計算しています</p>
+          </div>
+        </div>
+
+        <Card className="border-stone-200">
+          <CardContent className="px-0 py-1">
+            {STEPS.map((label, i) => {
+              const s = stepStatuses[i]
+              return (
+                <div
+                  key={label}
+                  className={[
+                    'flex items-center gap-3 px-4 py-2.5',
+                    i < STEPS.length - 1 ? 'border-b border-stone-100' : '',
+                  ].join(' ')}
+                >
+                  <StepIcon status={s} />
+                  <span
+                    className={[
+                      'flex-1 text-sm',
+                      s === 'pending' ? 'text-stone-400' : 'text-stone-800',
+                      s === 'active' ? 'font-medium' : '',
+                    ].join(' ')}
+                  >
+                    {label}
+                  </span>
+                  {s === 'done' && <span className="font-mono text-xs text-stone-400">done</span>}
+                  {s === 'active' && <span className="font-mono text-xs text-teal-500">...</span>}
+                </div>
+              )
+            })}
+          </CardContent>
+        </Card>
+
+        <p className="font-mono text-xs text-stone-400">
+          <span className="text-teal-500">►</span> job: {jobId}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function StepIcon({ status }: { status: StepStatus }) {
+  if (status === 'done') {
+    return (
+      <span className="flex size-5 items-center justify-center rounded-full bg-teal-600 text-white">
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 10 10"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path d="M2 5l2 2 4-4" />
+        </svg>
+      </span>
+    )
+  }
+  if (status === 'active') {
+    return (
+      <span className="flex size-5 items-center justify-center rounded-full border-2 border-teal-500 bg-teal-50">
+        <span className="size-2 rounded-full bg-teal-500" />
+      </span>
+    )
+  }
+  return <span className="size-5 rounded-full bg-stone-100" />
+}
+
+function Spinner({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-3 text-stone-400">
+      <SpinnerIcon />
+      <span className="text-sm">{label}</span>
+    </div>
+  )
+}
+
+function SpinnerIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      className="animate-spin"
+    >
+      <circle cx="10" cy="10" r="7" strokeDasharray="32" strokeDashoffset="8" />
+    </svg>
+  )
+}
+
+function CheckCircleIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <circle cx="9" cy="9" r="7" />
+      <path d="M5.5 9l2.5 2.5 4.5-4.5" />
+    </svg>
+  )
+}
+
+function ErrorIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <circle cx="9" cy="9" r="7" />
+      <path d="M9 6v4M9 12.5v.5" strokeLinecap="round" />
+    </svg>
+  )
 }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,14 +1,122 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { GitBranch } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import Header from '@/components/layout/Header'
+import { parsePrUrl } from '@/lib/prUrl'
+import { useAnalyzeMutation } from '@/hooks/useAnalysis'
+import { ApiError } from '@/lib/api'
 
-// TODO: PR URL 入力フォーム・解析リクエスト送信
 export default function Home() {
+  const [url, setUrl] = useState('')
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const navigate = useNavigate()
+  const mutation = useAnalyzeMutation()
+
+  const parsed = parsePrUrl(url)
+  const isValid = parsed !== null
+  const isEmpty = url.trim() === ''
+
+  const urlError =
+    !isEmpty && !isValid
+      ? '有効な GitHub PR URL を入力してください（例: https://github.com/owner/repo/pull/123）'
+      : null
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!isValid) return
+    setSubmitError(null)
+    mutation.mutate(url.trim(), {
+      onSuccess: (data) => navigate(`/analysis/${data.job_id}`),
+      onError: (err) => {
+        if (err instanceof ApiError) {
+          setSubmitError(err.message)
+        } else {
+          setSubmitError('予期しないエラーが発生しました')
+        }
+      },
+    })
+  }
+
   return (
-    <div>
+    <div className="min-h-svh bg-[#fafaf9]">
       <Header />
-      <main className="p-8 space-y-4">
-        <h1 className="text-2xl font-bold">ReviewArena</h1>
-        <Button>動作確認</Button>
+      <main className="mx-auto max-w-2xl px-6 py-16">
+        <p className="mb-2 font-mono text-xs text-stone-400 tracking-widest">STEP 1 / 2</p>
+        <h1 className="mb-2 text-3xl font-semibold tracking-tight text-stone-900">
+          解析するプルリクエストを指定
+        </h1>
+        <p className="mb-8 text-sm text-stone-500">
+          GitHub の PR URL を貼り付けると、リポジトリをクローンし、依存解析を始めます。
+        </p>
+
+        <Card className="border-stone-200 shadow-sm">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm font-medium text-stone-600">PR URL</CardTitle>
+            <CardDescription className="sr-only">GitHub PR の URL を入力</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit}>
+              <div className="flex gap-2">
+                <div className="relative flex-1">
+                  <Input
+                    value={url}
+                    onChange={(e) => {
+                      setUrl(e.target.value)
+                      setSubmitError(null)
+                    }}
+                    placeholder="https://github.com/owner/repo/pull/123"
+                    className={[
+                      'font-mono text-sm pr-16',
+                      isValid ? 'border-teal-600 focus-visible:ring-teal-600/30' : '',
+                    ].join(' ')}
+                    aria-invalid={!!urlError}
+                    autoFocus
+                  />
+                  {isValid && (
+                    <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs font-medium text-teal-600">
+                      ✓ 有効
+                    </span>
+                  )}
+                </div>
+                <Button
+                  type="submit"
+                  disabled={!isValid || mutation.isPending}
+                  className="shrink-0 bg-stone-900 hover:bg-stone-700"
+                >
+                  {mutation.isPending ? '送信中…' : '解析を開始'}
+                </Button>
+              </div>
+
+              {urlError && <p className="mt-2 text-xs text-red-500">{urlError}</p>}
+              {submitError && (
+                <p className="mt-2 rounded-md bg-red-50 px-3 py-2 text-xs text-red-600 border border-red-200">
+                  {submitError}
+                </p>
+              )}
+            </form>
+
+            {isValid && parsed && (
+              <div className="mt-4 rounded-lg bg-stone-50 border border-stone-100 px-4 py-3 text-xs text-stone-600 space-y-1">
+                <div className="flex justify-between">
+                  <span className="text-stone-400">リポジトリ</span>
+                  <span className="font-mono">
+                    {parsed.owner}/{parsed.repo}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-stone-400">PR #</span>
+                  <span className="font-mono flex items-center gap-1">
+                    <GitBranch className="size-3" />
+                    {parsed.number}
+                  </span>
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
       </main>
     </div>
   )


### PR DESCRIPTION
## Summary

- `pages/Home.tsx` に PR URL 入力フォームを実装（クライアント側バリデーション・✓ 有効表示・送信エラー表示）
- `pages/Analysis.tsx` に解析中 UI を実装（疑似ステップ進行・done/error 状態表示）
- `useAnalyzeMutation` / `useJobStatus` フックで `POST /api/analyze` → `GET /api/jobs/:id` ポーリングを実装
- `lib/prUrl.ts` でフロント側 URL フォーマット検証ユーティリティを追加
- `lib/api.ts` が Echo の JSON エラーレスポンス (`{ "message": "..." }`) を正しく拾うよう修正
- shadcn `input` / `card` コンポーネント追加

## 設計上の判断

| 点 | 方針 |
|---|---|
| Analyzing 5 ステップ進行 | backend は pending/running/done/error のみのため、elapsed time で疑似的にステップを進める |
| 最近の解析一覧 | `/api/analyses` が未実装なので今回スコープ外（別 issue 化） |
| PR メタ情報プレビュー | frontend 側でパース済みの `owner/repo#number` のみ表示（タイトル・ブランチは別途 API 設計が必要） |
| 非 Go リポジトリエラー | backend が返す `"no Go packages found"` を検知して日本語に変換 |
| フォント・色 | Home / Analysis ページのみ teal アクセントを適用。グローバルテーマは現状維持 |

## Test plan

- [x] `/` にアクセス → 未ログインで `/login` にリダイレクトされる
- [x] ログイン後、PR URL 入力フォームが表示される
- [x] 空欄のとき「解析を開始」ボタンが disabled
- [x] 不正 URL (`https://example.com/...`) を入力 → エラー文言が表示される・ボタン disabled のまま
- [x] 有効な URL を入力 → ✓ 有効 表示・`owner/repo#number` のプレビューが出る
- [x] 「解析を開始」送信 → `/analysis/:jobId` に遷移
- [x] 解析中は疑似ステップが時間経過で進む
- [x] job が `done` → 「解析が完了しました」表示
- [x] job が `error` (非 Go リポジトリ) → 「Go コードを含む PR ではありません」表示
- [x] lint / 型チェック: `docker compose run --rm frontend sh -c 'npm run lint && npx tsc -b'`

Closes #9