### PR TITLE
feat: グラフ可視化 UI + 外部パッケージ除外 (issue #10, #39)

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,2 @@
+tmp/
+bench

--- a/backend/cmd/bench/main.go
+++ b/backend/cmd/bench/main.go
@@ -1,0 +1,97 @@
+// bench は解析パイプラインの各フェーズの所要時間を計測するCLIツール。
+// 使い方: bench -token <GitHub PAT> -pr <PR URL>
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
+	"github.com/s-sh1m0/u-22_procon/backend/internal/infra/analyzer"
+	"github.com/s-sh1m0/u-22_procon/backend/internal/infra/cluster"
+	ghinfra "github.com/s-sh1m0/u-22_procon/backend/internal/infra/github"
+)
+
+func main() {
+	token := flag.String("token", os.Getenv("GITHUB_TOKEN"), "GitHub personal access token")
+	owner := flag.String("owner", "s-sh1m0", "repo owner")
+	repo := flag.String("repo", "u-22_procon", "repo name")
+	prNum := flag.Int("pr", 21, "PR number")
+	flag.Parse()
+
+	if *token == "" {
+		log.Fatal("GitHub token required: -token <token> or GITHUB_TOKEN env")
+	}
+
+	ctx := context.Background()
+
+	log.Printf("=== bench start: %s/%s#%d ===", *owner, *repo, *prNum)
+	tTotal := time.Now()
+
+	// 1. PR メタ情報取得
+	t0 := time.Now()
+	prRepo := ghinfra.NewPRRepo()
+	prInfo, err := prRepo.GetPR(ctx, *token, *owner, *repo, *prNum)
+	if err != nil {
+		log.Fatalf("GetPR: %v", err)
+	}
+	log.Printf("[1] GetPR took %s (head=%s)", time.Since(t0), prInfo.HeadSHA[:8])
+
+	// 2. 変更ファイル取得
+	t1 := time.Now()
+	changed, err := prRepo.ListChangedGoFiles(ctx, *token, *owner, *repo, *prNum)
+	if err != nil {
+		log.Fatalf("ListChangedGoFiles: %v", err)
+	}
+	log.Printf("[2] ListChangedGoFiles took %s (%d files)", time.Since(t1), len(changed))
+	for _, f := range changed {
+		fmt.Printf("    %s (%s)\n", f.Filename, f.Status)
+	}
+
+	// 3. clone + FastLoad + 近傍Load
+	t2 := time.Now()
+	sourceTree := analyzer.NewSourceTree(analyzer.NewGitCloner(), analyzer.NewGoPackageLoader())
+	prepared, err := sourceTree.Prepare(ctx, *prInfo, *token, changed)
+	if err != nil {
+		log.Fatalf("Prepare: %v", err)
+	}
+	defer func() { _ = prepared.Cleanup() }()
+	log.Printf("[3] Prepare (clone+load) took %s", time.Since(t2))
+	log.Printf("    packages loaded: %d, changed pkgs: %v", len(prepared.Packages), prepared.ChangedPackages)
+
+	// 4. コールグラフ構築
+	t3 := time.Now()
+	cgBuilder := analyzer.NewGoCallGraphBuilder()
+	graph, err := cgBuilder.Build(ctx, prepared.Packages, prepared.ChangedPackages)
+	if err != nil {
+		log.Fatalf("Build: %v", err)
+	}
+	log.Printf("[4] Build callgraph took %s (nodes=%d edges=%d)", time.Since(t3), len(graph.Nodes), len(graph.Edges))
+
+	// 5. クラスタリング
+	t4 := time.Now()
+	clusterer := cluster.NewLouvainClusterer()
+	_, err = clusterer.Cluster(ctx, graph)
+	if err != nil {
+		log.Fatalf("Cluster: %v", err)
+	}
+	log.Printf("[5] Cluster took %s", time.Since(t4))
+
+	log.Printf("=== total: %s ===", time.Since(tTotal))
+
+	// 6. グラフの中身確認（外部パッケージが混じっていないかチェック）
+	fmt.Println("\n--- nodes (package) ---")
+	pkgCount := make(map[string]int)
+	for _, n := range graph.Nodes {
+		pkgCount[n.Package]++
+	}
+	for pkg, cnt := range pkgCount {
+		fmt.Printf("  %s (%d nodes)\n", pkg, cnt)
+	}
+
+	_ = domain.PRInfo{}
+}

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -43,6 +43,14 @@ func main() {
 	analysisRepo := store.NewAnalysisRepo(db)
 	jobRepo := store.NewJobRepo(db)
 
+	// 再起動で処理されなくなった pending/running ジョブをエラーに更新する。
+	// トークンは DB に保存していないため再キューイングは不可。ユーザーに再送信を促す。
+	if n, err := jobRepo.MarkStaleJobsError(context.Background()); err != nil {
+		log.Printf("warn: mark stale jobs: %v", err)
+	} else if n > 0 {
+		log.Printf("startup: marked %d stale job(s) as error (server restarted)", n)
+	}
+
 	prRepo := githubinfra.NewPRRepo()
 	sourceTree := analyzer.NewSourceTree(analyzer.NewGitCloner(), analyzer.NewGoPackageLoader())
 	cgBuilder := analyzer.NewGoCallGraphBuilder()

--- a/backend/internal/api/analysis_handler.go
+++ b/backend/internal/api/analysis_handler.go
@@ -93,7 +93,7 @@ func (h *AnalysisHandler) GetGraph(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("get graph: %v", err))
 	}
 
-	return c.JSON(http.StatusOK, toGraphResponse(analysis.Result))
+	return c.JSON(http.StatusOK, toGraphResponse(analysis))
 }
 
 // parsePRURL は GitHub PR の URL をパースして PRInfo を返す。

--- a/backend/internal/api/analysis_handler_test.go
+++ b/backend/internal/api/analysis_handler_test.go
@@ -175,7 +175,11 @@ func TestGetGraph_Success(t *testing.T) {
 			Edges: []domain.Edge{},
 		},
 	}
-	analysis := &domain.Analysis{ID: "a1", Result: result}
+	analysis := &domain.Analysis{
+		ID:     "a1",
+		PR:     domain.PRInfo{Owner: "owner", Repo: "repo", Number: 42, Title: "test PR"},
+		Result: result,
+	}
 	h := NewAnalysisHandler(&fakeAnalyzeUC{}, &fakeReadUC{analysis: analysis})
 
 	e := echo.New()
@@ -200,6 +204,9 @@ func TestGetGraph_Success(t *testing.T) {
 	}
 	if len(resp.Graph.Nodes) != 1 {
 		t.Errorf("expected 1 node, got %d", len(resp.Graph.Nodes))
+	}
+	if resp.PR.Owner != "owner" {
+		t.Errorf("expected PR.Owner=owner, got %s", resp.PR.Owner)
 	}
 }
 

--- a/backend/internal/api/dto.go
+++ b/backend/internal/api/dto.go
@@ -20,8 +20,19 @@ type MeResponse struct {
 	Login string `json:"login"`
 }
 
+// PRInfoDTO は PR 基本情報の JSON 表現
+type PRInfoDTO struct {
+	Owner   string `json:"owner"`
+	Repo    string `json:"repo"`
+	Number  int    `json:"number"`
+	Title   string `json:"title"`
+	BaseRef string `json:"base_ref"`
+	HeadRef string `json:"head_ref"`
+}
+
 // GraphResponse は GET /api/graph/:jobId のレスポンス
 type GraphResponse struct {
+	PR       PRInfoDTO    `json:"pr"`
 	Clusters []ClusterDTO `json:"clusters"`
 	Graph    GraphDTO     `json:"graph"`
 }
@@ -55,8 +66,9 @@ type EdgeDTO struct {
 	To   string `json:"to"`
 }
 
-// toGraphResponse は domain.ClusterResult を GraphResponse に変換する。
-func toGraphResponse(r *domain.ClusterResult) GraphResponse {
+// toGraphResponse は domain.Analysis を GraphResponse に変換する。
+func toGraphResponse(a *domain.Analysis) GraphResponse {
+	r := a.Result
 	clusters := make([]ClusterDTO, len(r.Clusters))
 	for i, c := range r.Clusters {
 		nodes := make([]string, len(c.Nodes))
@@ -84,6 +96,14 @@ func toGraphResponse(r *domain.ClusterResult) GraphResponse {
 	}
 
 	return GraphResponse{
+		PR: PRInfoDTO{
+			Owner:   a.PR.Owner,
+			Repo:    a.PR.Repo,
+			Number:  a.PR.Number,
+			Title:   a.PR.Title,
+			BaseRef: a.PR.BaseRef,
+			HeadRef: a.PR.HeadRef,
+		},
 		Clusters: clusters,
 		Graph:    GraphDTO{Nodes: nodes, Edges: edges},
 	}

--- a/backend/internal/infra/analyzer/callgraph.go
+++ b/backend/internal/infra/analyzer/callgraph.go
@@ -46,25 +46,34 @@ func (b *GoCallGraphBuilder) Build(_ context.Context, pkgs []*packages.Package, 
 		maxDepth = defaultMaxDepth
 	}
 
-	// 1. SSA プログラムを構築
-	prog, _ := ssautil.AllPackages(pkgs, ssa.InstantiateGenerics)
+	// 1. プロジェクト内パッケージのみを抽出する。
+	// NeedDeps によって pkgs には外部ライブラリも含まれるが、SSA 構築と
+	// loadedSet はプロジェクト内パッケージのみを対象にする。
+	// pkg.Module.Main が true のパッケージが自リポジトリのパッケージ。
+	projectPkgs := make([]*packages.Package, 0, len(pkgs))
+	for _, pkg := range pkgs {
+		if pkg.Module != nil && pkg.Module.Main {
+			projectPkgs = append(projectPkgs, pkg)
+		}
+	}
+
+	// 2. SSA プログラムを構築（プロジェクト内パッケージのみ）
+	prog, _ := ssautil.AllPackages(projectPkgs, ssa.InstantiateGenerics)
 	prog.Build()
 
-	// 2. CHA でコールグラフ構築（エントリポイント不要 → ライブラリにも適用可）
+	// 3. CHA でコールグラフ構築（エントリポイント不要 → ライブラリにも適用可）
 	cg := cha.CallGraph(prog)
 	cg.DeleteSyntheticNodes()
 
-	// 3. 変更パッケージ ID セット
+	// 4. 変更パッケージ ID セット
 	changedSet := make(map[string]struct{}, len(changedPkgIDs))
 	for _, id := range changedPkgIDs {
 		changedSet[id] = struct{}{}
 	}
 
-	// 4. ロード済みパッケージ ID セット（stdlib・外部ライブラリ除外用）
-	// packages.Visit は推移的依存も辿るため、packages.Load("./...") が直接返した
-	// プロジェクト内パッケージのみを対象にする。
-	loadedSet := make(map[string]struct{}, len(pkgs))
-	for _, pkg := range pkgs {
+	// 5. プロジェクト内パッケージ ID セット（外部ライブラリ除外用）
+	loadedSet := make(map[string]struct{}, len(projectPkgs))
+	for _, pkg := range projectPkgs {
 		loadedSet[pkg.ID] = struct{}{}
 	}
 

--- a/backend/internal/infra/analyzer/callgraph.go
+++ b/backend/internal/infra/analyzer/callgraph.go
@@ -61,11 +61,12 @@ func (b *GoCallGraphBuilder) Build(_ context.Context, pkgs []*packages.Package, 
 	}
 
 	// 4. ロード済みパッケージ ID セット（stdlib・外部ライブラリ除外用）
-	loadedSet := make(map[string]struct{})
-	packages.Visit(pkgs, func(pkg *packages.Package) bool {
+	// packages.Visit は推移的依存も辿るため、packages.Load("./...") が直接返した
+	// プロジェクト内パッケージのみを対象にする。
+	loadedSet := make(map[string]struct{}, len(pkgs))
+	for _, pkg := range pkgs {
 		loadedSet[pkg.ID] = struct{}{}
-		return true
-	}, nil)
+	}
 
 	// 5. 変更パッケージの関数を起点に BFS（双方向、maxDepth ホップ）
 	type entry struct {

--- a/backend/internal/infra/analyzer/parser.go
+++ b/backend/internal/infra/analyzer/parser.go
@@ -29,17 +29,29 @@ const loadMode = packages.NeedName |
 	packages.NeedTypesSizes |
 	packages.NeedModule
 
+// fastLoadMode は型チェックなしでパッケージ構造だけを取得する高速フラグ。
+// NeedImports まで含めることで import グラフから近傍パッケージを特定できる。
+const fastLoadMode = packages.NeedName |
+	packages.NeedFiles |
+	packages.NeedImports |
+	packages.NeedModule
+
 // LoadResult はパッケージロードの結果。
 type LoadResult struct {
-	// Packages はtransitivelyロードされた全パッケージ。
+	// Packages はロードされたパッケージ。
 	Packages []*packages.Package
 	// Errors はパッケージ個別の型エラー等（致命エラーではない）。
 	Errors []packages.Error
 }
 
-// PackageLoader はgo/packagesでディレクトリ配下のパッケージ群をロードする抽象。
+// PackageLoader はgo/packagesでパッケージ群をロードする抽象。
 type PackageLoader interface {
-	Load(ctx context.Context, rootDir string) (*LoadResult, error)
+	// FastLoad は型チェックなしでパッケージ構造だけを高速ロードする。
+	// 変更パッケージ特定と近傍計算に使う。
+	FastLoad(ctx context.Context, rootDir string) ([]*packages.Package, error)
+	// Load は指定パターンのパッケージを型情報付きでロードする。
+	// patterns はパッケージインポートパスのリスト。
+	Load(ctx context.Context, rootDir string, patterns []string) (*LoadResult, error)
 }
 
 // GoPackageLoader はgo/packagesを使う本番実装。
@@ -50,19 +62,50 @@ func NewGoPackageLoader() *GoPackageLoader {
 	return &GoPackageLoader{}
 }
 
-// Load はrootDir配下の全Goパッケージを型情報付きでロードする。
+// FastLoad はrootDir配下の全Goパッケージを型チェックなしで高速ロードする。
+// 変更パッケージの特定と近傍パッケージの計算にのみ使う。
+func (l *GoPackageLoader) FastLoad(ctx context.Context, rootDir string) ([]*packages.Package, error) {
+	cfg := &packages.Config{
+		Mode:    fastLoadMode,
+		Dir:     rootDir,
+		Context: ctx,
+		Tests:   false,
+		Env:     append(os.Environ(), "GOWORK=off"),
+	}
+
+	pkgs, err := packages.Load(cfg, "./...")
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrNoPackages, err)
+	}
+
+	var usable int
+	for _, pkg := range pkgs {
+		if len(pkg.GoFiles) > 0 {
+			usable++
+		}
+	}
+	if usable == 0 {
+		return nil, ErrNoPackages
+	}
+	return pkgs, nil
+}
+
+// Load はpatterns で指定したパッケージを型情報付きでロードする。
 // GOWORK=offを強制してホスト環境のgo.workの影響を受けないようにする。
-func (l *GoPackageLoader) Load(ctx context.Context, rootDir string) (*LoadResult, error) {
+func (l *GoPackageLoader) Load(ctx context.Context, rootDir string, patterns []string) (*LoadResult, error) {
+	if len(patterns) == 0 {
+		return &LoadResult{}, nil
+	}
+
 	cfg := &packages.Config{
 		Mode:    loadMode,
 		Dir:     rootDir,
 		Context: ctx,
 		Tests:   false,
-		// GOWORK=off: 開発機の外側go.workがcloneされたモジュールの解析に干渉しないよう強制
-		Env: append(os.Environ(), "GOWORK=off"),
+		Env:     append(os.Environ(), "GOWORK=off"),
 	}
 
-	pkgs, err := packages.Load(cfg, "./...")
+	pkgs, err := packages.Load(cfg, patterns...)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrNoPackages, err)
 	}
@@ -73,8 +116,6 @@ func (l *GoPackageLoader) Load(ctx context.Context, rootDir string) (*LoadResult
 		errs = append(errs, pkg.Errors...)
 	})
 
-	// GoFilesが1件もないならGoパッケージが存在しないと判断する。
-	// packages.Loadはgo.modが無い空ディレクトリでも0件ではなくエラー付きエントリを返すことがあるため。
 	var usable int
 	for _, pkg := range pkgs {
 		if len(pkg.GoFiles) > 0 || len(pkg.CompiledGoFiles) > 0 {
@@ -127,6 +168,75 @@ func IdentifyChangedPackages(rootDir string, pkgs []*packages.Package, changed [
 
 	result := make([]string, 0, len(seen))
 	for id := range seen {
+		result = append(result, id)
+	}
+	sort.Strings(result)
+	return result
+}
+
+// FindNeighborhood は変更パッケージを起点に import グラフを maxDepth ホップ辿った
+// プロジェクト内パッケージのIDスライスを返す（重複なし・ソート済み）。
+// allPkgs は FastLoad で得たプロジェクト内パッケージのみを想定する。
+// 外部ライブラリは含まない。
+func FindNeighborhood(changedPkgs []string, allPkgs []*packages.Package, maxDepth int) []string {
+	// プロジェクトパッケージIDセット
+	projectIDs := make(map[string]struct{}, len(allPkgs))
+	for _, pkg := range allPkgs {
+		projectIDs[pkg.ID] = struct{}{}
+	}
+
+	// 前方 import グラフ（callee方向: pkg → import先プロジェクトパッケージ）
+	forward := make(map[string][]string, len(allPkgs))
+	for _, pkg := range allPkgs {
+		for impPath := range pkg.Imports {
+			if _, ok := projectIDs[impPath]; ok {
+				forward[pkg.ID] = append(forward[pkg.ID], impPath)
+			}
+		}
+	}
+
+	// 逆 import グラフ（caller方向: pkg → import元プロジェクトパッケージ）
+	reverse := make(map[string][]string, len(allPkgs))
+	for callerID, callees := range forward {
+		for _, calleeID := range callees {
+			reverse[calleeID] = append(reverse[calleeID], callerID)
+		}
+	}
+
+	// BFS（双方向、maxDepth ホップ）
+	type entry struct {
+		id    string
+		depth int
+	}
+	visited := make(map[string]struct{})
+	queue := make([]entry, 0, len(changedPkgs))
+	for _, id := range changedPkgs {
+		if _, ok := projectIDs[id]; !ok {
+			continue
+		}
+		if _, ok := visited[id]; !ok {
+			visited[id] = struct{}{}
+			queue = append(queue, entry{id, 0})
+		}
+	}
+
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		if cur.depth >= maxDepth {
+			continue
+		}
+		neighbors := append(forward[cur.id], reverse[cur.id]...)
+		for _, nid := range neighbors {
+			if _, ok := visited[nid]; !ok {
+				visited[nid] = struct{}{}
+				queue = append(queue, entry{nid, cur.depth + 1})
+			}
+		}
+	}
+
+	result := make([]string, 0, len(visited))
+	for id := range visited {
 		result = append(result, id)
 	}
 	sort.Strings(result)

--- a/backend/internal/infra/analyzer/parser_test.go
+++ b/backend/internal/infra/analyzer/parser_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"golang.org/x/tools/go/packages"
@@ -29,6 +30,52 @@ func writeFixture(t *testing.T, files map[string]string) string {
 	return dir
 }
 
+func TestGoPackageLoader_FastLoad_Fixture(t *testing.T) {
+	dir := writeFixture(t, map[string]string{
+		"go.mod": "module example.com/fixture\n\ngo 1.21\n",
+		"pkg/a/a.go": `package a
+
+import "example.com/fixture/pkg/b"
+
+func F() int { return b.G() }
+`,
+		"pkg/b/b.go": `package b
+
+func G() int { return 42 }
+`,
+	})
+
+	loader := NewGoPackageLoader()
+	pkgs, err := loader.FastLoad(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("FastLoad: %v", err)
+	}
+
+	pkgIDs := make(map[string]struct{})
+	for _, pkg := range pkgs {
+		pkgIDs[pkg.ID] = struct{}{}
+	}
+
+	for _, want := range []string{"example.com/fixture/pkg/a", "example.com/fixture/pkg/b"} {
+		if _, ok := pkgIDs[want]; !ok {
+			t.Errorf("package %q not found; got: %v", want, pkgIDs)
+		}
+	}
+}
+
+func TestGoPackageLoader_FastLoad_NoModule(t *testing.T) {
+	dir := t.TempDir()
+
+	loader := NewGoPackageLoader()
+	_, err := loader.FastLoad(context.Background(), dir)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrNoPackages) {
+		t.Errorf("expected ErrNoPackages, got: %v", err)
+	}
+}
+
 func TestGoPackageLoader_Load_Fixture(t *testing.T) {
 	dir := writeFixture(t, map[string]string{
 		"go.mod": "module example.com/fixture\n\ngo 1.21\n",
@@ -45,7 +92,7 @@ func G() int { return 42 }
 	})
 
 	loader := NewGoPackageLoader()
-	result, err := loader.Load(context.Background(), dir)
+	result, err := loader.Load(context.Background(), dir, []string{"./..."})
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -80,10 +127,10 @@ func G() int { return 42 }
 }
 
 func TestGoPackageLoader_Load_NoModule(t *testing.T) {
-	dir := t.TempDir() // 空ディレクトリ（go.modなし）
+	dir := t.TempDir()
 
 	loader := NewGoPackageLoader()
-	_, err := loader.Load(context.Background(), dir)
+	_, err := loader.Load(context.Background(), dir, []string{"./..."})
 	if err == nil {
 		t.Fatal("expected error for empty directory, got nil")
 	}
@@ -102,13 +149,32 @@ func F() int { return "not an int" } // 型エラー
 	})
 
 	loader := NewGoPackageLoader()
-	result, err := loader.Load(context.Background(), dir)
+	result, err := loader.Load(context.Background(), dir, []string{"./..."})
 	// 型エラーがあっても Load 自体は成功して Errors に詰めて返す
 	if err != nil {
 		t.Fatalf("Load returned error: %v", err)
 	}
 	if len(result.Errors) == 0 {
 		t.Error("expected at least one type error in result.Errors, got none")
+	}
+}
+
+func TestGoPackageLoader_Load_EmptyPatterns(t *testing.T) {
+	dir := writeFixture(t, map[string]string{
+		"go.mod": "module example.com/fixture\n\ngo 1.21\n",
+		"pkg/a/a.go": `package a
+
+func F() {}
+`,
+	})
+
+	loader := NewGoPackageLoader()
+	result, err := loader.Load(context.Background(), dir, []string{})
+	if err != nil {
+		t.Fatalf("Load with empty patterns: %v", err)
+	}
+	if len(result.Packages) != 0 {
+		t.Errorf("expected empty packages, got %d", len(result.Packages))
 	}
 }
 
@@ -128,9 +194,10 @@ func G() int { return 42 }
 	})
 
 	loader := NewGoPackageLoader()
-	result, err := loader.Load(context.Background(), dir)
+	// IdentifyChangedPackages は GoFiles 情報だけあれば動作するので FastLoad で足りる
+	pkgs, err := loader.FastLoad(context.Background(), dir)
 	if err != nil {
-		t.Fatalf("Load: %v", err)
+		t.Fatalf("FastLoad: %v", err)
 	}
 
 	tests := []struct {
@@ -170,7 +237,7 @@ func G() int { return 42 }
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := IdentifyChangedPackages(dir, result.Packages, tc.changed)
+			got := IdentifyChangedPackages(dir, pkgs, tc.changed)
 			if len(got) != len(tc.want) {
 				t.Errorf("got %v, want %v", got, tc.want)
 				return
@@ -179,6 +246,100 @@ func G() int { return 42 }
 				if id != tc.want[i] {
 					t.Errorf("[%d] got %q, want %q", i, id, tc.want[i])
 				}
+			}
+		})
+	}
+}
+
+func TestFindNeighborhood(t *testing.T) {
+	// fixture: a → b → c という import チェーン、d は孤立
+	dir := writeFixture(t, map[string]string{
+		"go.mod": "module example.com/fixture\n\ngo 1.21\n",
+		"pkg/a/a.go": `package a
+
+import "example.com/fixture/pkg/b"
+
+func FA() { b.FB() }
+`,
+		"pkg/b/b.go": `package b
+
+import "example.com/fixture/pkg/c"
+
+func FB() { c.FC() }
+`,
+		"pkg/c/c.go": `package c
+
+func FC() {}
+`,
+		"pkg/d/d.go": `package d
+
+func FD() {}
+`,
+	})
+
+	loader := NewGoPackageLoader()
+	fastPkgs, err := loader.FastLoad(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("FastLoad: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		changedPkgs  []string
+		maxDepth     int
+		wantIncludes []string
+		wantExcludes []string
+	}{
+		{
+			name:         "pkg/b変更・depth=1: aとcが近傍に入る",
+			changedPkgs:  []string{"example.com/fixture/pkg/b"},
+			maxDepth:     1,
+			wantIncludes: []string{"example.com/fixture/pkg/a", "example.com/fixture/pkg/b", "example.com/fixture/pkg/c"},
+			wantExcludes: []string{"example.com/fixture/pkg/d"},
+		},
+		{
+			name:         "pkg/c変更・depth=1: bが近傍に入るがaは入らない",
+			changedPkgs:  []string{"example.com/fixture/pkg/c"},
+			maxDepth:     1,
+			wantIncludes: []string{"example.com/fixture/pkg/b", "example.com/fixture/pkg/c"},
+			wantExcludes: []string{"example.com/fixture/pkg/a", "example.com/fixture/pkg/d"},
+		},
+		{
+			name:         "pkg/c変更・depth=2: aまで到達",
+			changedPkgs:  []string{"example.com/fixture/pkg/c"},
+			maxDepth:     2,
+			wantIncludes: []string{"example.com/fixture/pkg/a", "example.com/fixture/pkg/b", "example.com/fixture/pkg/c"},
+			wantExcludes: []string{"example.com/fixture/pkg/d"},
+		},
+		{
+			name:         "孤立パッケージ変更: 自分のみ",
+			changedPkgs:  []string{"example.com/fixture/pkg/d"},
+			maxDepth:     3,
+			wantIncludes: []string{"example.com/fixture/pkg/d"},
+			wantExcludes: []string{"example.com/fixture/pkg/a", "example.com/fixture/pkg/b", "example.com/fixture/pkg/c"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FindNeighborhood(tc.changedPkgs, fastPkgs, tc.maxDepth)
+			gotSet := make(map[string]struct{}, len(got))
+			for _, id := range got {
+				gotSet[id] = struct{}{}
+			}
+			for _, want := range tc.wantIncludes {
+				if _, ok := gotSet[want]; !ok {
+					t.Errorf("expected %q in neighborhood, got: %v", want, got)
+				}
+			}
+			for _, notWant := range tc.wantExcludes {
+				if _, ok := gotSet[notWant]; ok {
+					t.Errorf("unexpected %q in neighborhood, got: %v", notWant, got)
+				}
+			}
+			// ソート済みであることを確認
+			if !sort.StringsAreSorted(got) {
+				t.Errorf("result is not sorted: %v", got)
 			}
 		})
 	}

--- a/backend/internal/infra/analyzer/source_tree.go
+++ b/backend/internal/infra/analyzer/source_tree.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"golang.org/x/tools/go/packages"
 
@@ -34,7 +36,11 @@ func NewSourceTree(c Cloner, l PackageLoader) *SourceTree {
 	return &SourceTree{Cloner: c, Loader: l}
 }
 
-// Prepare は clone → load → 変更パッケージ特定 を一気に実施する。
+// Prepare は clone → fast load → 変更パッケージ特定 → 近傍フルロード を一気に実施する。
+//
+// 2フェーズロードにより、プロジェクト内の変更パッケージとその近傍のみを
+// 型情報付きでロードし、外部ライブラリを含む全パッケージのロードを回避する。
+//
 // Loadが失敗したときはCloneのCleanupを内部で呼んでから返す（呼び出し側に部分状態を渡さない）。
 // 成功時のみPreparedSource.Cleanupが返り、呼び出し側がdeferで呼ぶ責務を持つ。
 // モノレポ対応: cloneルートでパッケージが見つからない場合、go.mod を持つサブディレクトリを自動検出する。
@@ -58,14 +64,42 @@ func (s *SourceTree) Prepare(ctx context.Context, pr domain.PRInfo, token string
 		return nil, fmt.Errorf("analyzer: find go.mod in %s: %w", clonedRoot, err)
 	}
 
-	result, err := s.Loader.Load(ctx, loadDir)
+	// Phase 1: 型チェックなしで全プロジェクトパッケージの構造を高速ロード。
+	// import グラフのみ取得し、変更パッケージとその近傍を特定する。
+	t0 := time.Now()
+	fastPkgs, err := s.Loader.FastLoad(ctx, loadDir)
+	if err != nil {
+		_ = cloned.Cleanup()
+		return nil, fmt.Errorf("analyzer: fast-load packages at %s: %w", loadDir, err)
+	}
+	log.Printf("analyzer: phase1 FastLoad(%d pkgs) took %s", len(fastPkgs), time.Since(t0))
+
+	// GitHub API の changed ファイルパスはリポジトリルート相対なので clonedRoot を基点にする。
+	changedPkgs := IdentifyChangedPackages(clonedRoot, fastPkgs, changed)
+	log.Printf("analyzer: changed packages: %v", changedPkgs)
+
+	if len(changedPkgs) == 0 {
+		// 変更されたGoパッケージがない（非Goファイルのみの変更など）
+		return &PreparedSource{
+			RootDir:         loadDir,
+			ChangedPackages: nil,
+			Cleanup:         cloned.Cleanup,
+		}, nil
+	}
+
+	// Phase 2: 変更パッケージとその近傍（defaultMaxDepth ホップ以内）のみを
+	// 型情報付きでロードする。外部ライブラリは型チェックの依存として読まれるが
+	// 返却パッケージには含まれない。
+	neighborhood := FindNeighborhood(changedPkgs, fastPkgs, defaultMaxDepth)
+	log.Printf("analyzer: neighborhood(%d pkgs): %v", len(neighborhood), neighborhood)
+
+	t1 := time.Now()
+	result, err := s.Loader.Load(ctx, loadDir, neighborhood)
 	if err != nil {
 		_ = cloned.Cleanup()
 		return nil, fmt.Errorf("analyzer: load packages at %s: %w", loadDir, err)
 	}
-
-	// GitHub API の changed ファイルパスはリポジトリルート相対なので clonedRoot を基点にする。
-	changedPkgs := IdentifyChangedPackages(clonedRoot, result.Packages, changed)
+	log.Printf("analyzer: phase2 Load(%d pkgs) took %s", len(result.Packages), time.Since(t1))
 
 	return &PreparedSource{
 		RootDir:         loadDir,

--- a/backend/internal/infra/analyzer/source_tree_test.go
+++ b/backend/internal/infra/analyzer/source_tree_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"golang.org/x/tools/go/packages"
+
 	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
 )
 
@@ -37,7 +39,11 @@ func (e *errorCloner) Clone(_ context.Context, _ CloneRequest) (*ClonedRepo, err
 // errorLoader は常にエラーを返すPackageLoader。
 type errorLoader struct{}
 
-func (e *errorLoader) Load(_ context.Context, _ string) (*LoadResult, error) {
+func (e *errorLoader) FastLoad(_ context.Context, _ string) ([]*packages.Package, error) {
+	return nil, ErrNoPackages
+}
+
+func (e *errorLoader) Load(_ context.Context, _ string, _ []string) (*LoadResult, error) {
 	return nil, ErrNoPackages
 }
 

--- a/backend/internal/infra/job/worker.go
+++ b/backend/internal/infra/job/worker.go
@@ -97,36 +97,47 @@ func (w *Worker) process(ctx context.Context, item Item) {
 		return
 	}
 
+	tStart := time.Now()
+
 	prInfo, err := w.prRepo.GetPR(ctx, item.Token, j.PR.Owner, j.PR.Repo, j.PR.Number)
 	if err != nil {
 		fail(fmt.Errorf("get PR: %w", err))
 		return
 	}
 
+	t0 := time.Now()
 	changed, err := w.prRepo.ListChangedGoFiles(ctx, item.Token, j.PR.Owner, j.PR.Repo, j.PR.Number)
 	if err != nil {
 		fail(fmt.Errorf("list changed files: %w", err))
 		return
 	}
+	log.Printf("worker: ListChangedGoFiles took %s (%d files)", time.Since(t0), len(changed))
 
+	t1 := time.Now()
 	prepared, err := w.sourceTree.Prepare(ctx, *prInfo, item.Token, changed)
 	if err != nil {
 		fail(fmt.Errorf("prepare source: %w", err))
 		return
 	}
 	defer func() { _ = prepared.Cleanup() }()
+	log.Printf("worker: Prepare (clone+load) took %s", time.Since(t1))
 
+	t2 := time.Now()
 	graph, err := w.cgBuilder.Build(ctx, prepared.Packages, prepared.ChangedPackages)
 	if err != nil {
 		fail(fmt.Errorf("build callgraph: %w", err))
 		return
 	}
+	log.Printf("worker: Build callgraph took %s (nodes=%d edges=%d)", time.Since(t2), len(graph.Nodes), len(graph.Edges))
 
+	t3 := time.Now()
 	result, err := w.clusterer.Cluster(ctx, graph)
 	if err != nil {
 		fail(fmt.Errorf("cluster: %w", err))
 		return
 	}
+	log.Printf("worker: Cluster took %s", time.Since(t3))
+	log.Printf("worker: total job %s took %s", jobID, time.Since(tStart))
 
 	analysisID := domain.AnalysisID(w.newID())
 	a := &domain.Analysis{

--- a/backend/internal/infra/store/job_repo.go
+++ b/backend/internal/infra/store/job_repo.go
@@ -66,6 +66,21 @@ func (r *JobRepo) UpdateAnalysisID(ctx context.Context, id domain.JobID, analysi
 	return nil
 }
 
+// MarkStaleJobsError はサーバ起動時に pending/running のままになっているジョブを
+// error 状態にする。再起動でインメモリキューが消えて処理されないジョブを残さないため。
+func (r *JobRepo) MarkStaleJobsError(ctx context.Context) (int64, error) {
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE jobs SET status='error', error='server restarted', updated_at=?
+		 WHERE status IN ('pending', 'running')`,
+		time.Now().UTC(),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("mark stale jobs: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
 // FindByID は ID でジョブを返す。存在しない場合は (nil, nil) を返す。
 func (r *JobRepo) FindByID(ctx context.Context, id domain.JobID) (*domain.Job, error) {
 	var (

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,13 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>diffmap.</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/branding/Brand.tsx
+++ b/frontend/src/components/branding/Brand.tsx
@@ -1,0 +1,23 @@
+type Props = { size?: number }
+
+export default function Brand({ size = 16 }: Props) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <svg width={size + 2} height={size + 2} viewBox="0 0 18 18" fill="none" aria-hidden="true">
+        <rect x="1" y="1" width="16" height="16" rx="4" fill="#0f766e" />
+        <path d="M5 9h8M9 5v8" stroke="white" strokeWidth="2" strokeLinecap="round" />
+      </svg>
+      <span
+        style={{
+          fontFamily: "'Inter Tight', sans-serif",
+          fontSize: size,
+          color: '#0f766e',
+          fontWeight: 600,
+          letterSpacing: '-0.01em',
+        }}
+      >
+        diffmap.
+      </span>
+    </div>
+  )
+}

--- a/frontend/src/components/graph/ClusterGroup.tsx
+++ b/frontend/src/components/graph/ClusterGroup.tsx
@@ -1,4 +1,20 @@
-// TODO: クラスタをグループノードとして描画する
-export default function ClusterGroup() {
-  return <div>ClusterGroup</div>
+import type { NodeProps } from '@xyflow/react'
+import type { ClusterFlowNode } from '@/types/graph'
+
+export default function ClusterGroup({ data }: NodeProps<ClusterFlowNode>) {
+  return (
+    <div
+      className="size-full rounded-xl border"
+      style={{
+        background: `color-mix(in srgb, ${data.clusterColorSoft} 60%, white)`,
+        border: `1.5px solid color-mix(in srgb, ${data.clusterColorHex} 35%, transparent)`,
+      }}
+    >
+      <div className="px-3 pt-2">
+        <span className="text-xs font-semibold" style={{ color: data.clusterColorHex }}>
+          {data.label}
+        </span>
+      </div>
+    </div>
+  )
 }

--- a/frontend/src/components/graph/DependencyGraph.tsx
+++ b/frontend/src/components/graph/DependencyGraph.tsx
@@ -1,4 +1,102 @@
-// TODO: @xyflow/react をラップした依存グラフのルートコンポーネント・レイアウト計算
-export default function DependencyGraph() {
-  return <div>DependencyGraph</div>
+import { useMemo, useCallback } from 'react'
+import {
+  ReactFlow,
+  Background,
+  BackgroundVariant,
+  Controls,
+  MiniMap,
+  ReactFlowProvider,
+  Panel,
+  useReactFlow,
+  type NodeMouseHandler,
+} from '@xyflow/react'
+import type { GraphResponse } from '@/types/api'
+import type { NodeKind } from '@/types/graph'
+import FunctionNode from './FunctionNode'
+import FileNode from './FileNode'
+import ClusterGroup from './ClusterGroup'
+import GraphControls from './GraphControls'
+import { layoutGraph } from '@/lib/graphLayout'
+
+const nodeTypes = {
+  function: FunctionNode,
+  file: FileNode,
+  cluster: ClusterGroup,
+}
+
+type Props = {
+  data: GraphResponse
+  nodeKind: NodeKind
+  onChangeNodeKind: (kind: NodeKind) => void
+  selectedNodeId: string | null
+  onSelectNode: (id: string) => void
+}
+
+function GraphInner({ data, nodeKind, onChangeNodeKind, selectedNodeId, onSelectNode }: Props) {
+  const { fitView } = useReactFlow()
+
+  const { nodes: layoutNodes, edges } = useMemo(() => layoutGraph(data, nodeKind), [data, nodeKind])
+
+  const nodes = useMemo(
+    () => layoutNodes.map((n) => ({ ...n, selected: n.id === selectedNodeId })),
+    [layoutNodes, selectedNodeId],
+  )
+
+  const handleNodeClick: NodeMouseHandler = useCallback(
+    (_, node) => {
+      if (node.type === 'function' || node.type === 'file') {
+        onSelectNode(node.id)
+      }
+    },
+    [onSelectNode],
+  )
+
+  const handleFitChanged = useCallback(() => {
+    const changedNodes = nodes.filter(
+      (n) =>
+        (n.type === 'function' || n.type === 'file') && (n.data as { changed?: boolean }).changed,
+    )
+    if (changedNodes.length > 0) {
+      fitView({ nodes: changedNodes.map((n) => ({ id: n.id })), duration: 400, padding: 0.3 })
+    } else {
+      fitView({ duration: 300 })
+    }
+  }, [fitView, nodes])
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      nodeTypes={nodeTypes}
+      fitView
+      minZoom={0.05}
+      maxZoom={2.5}
+      onNodeClick={handleNodeClick}
+      proOptions={{ hideAttribution: false }}
+    >
+      <Background variant={BackgroundVariant.Dots} gap={20} color="#e7e5e4" />
+      <Controls position="bottom-left" />
+      <MiniMap
+        nodeColor={(n) => (n.type === 'cluster' ? '#e7e5e4' : '#0d9488')}
+        maskColor="rgba(250,250,249,0.6)"
+      />
+      <Panel position="bottom-right">
+        <GraphControls
+          nodeKind={nodeKind}
+          onChangeNodeKind={onChangeNodeKind}
+          onFitChanged={handleFitChanged}
+        />
+      </Panel>
+    </ReactFlow>
+  )
+}
+
+export default function DependencyGraph(props: Props) {
+  return (
+    <ReactFlowProvider>
+      <div className="size-full min-h-0">
+        <GraphInner {...props} />
+      </div>
+    </ReactFlowProvider>
+  )
 }

--- a/frontend/src/components/graph/FileNode.tsx
+++ b/frontend/src/components/graph/FileNode.tsx
@@ -1,12 +1,12 @@
 import { Handle, Position, type NodeProps } from '@xyflow/react'
-import type { FunctionFlowNode } from '@/types/graph'
+import type { FileFlowNode } from '@/types/graph'
 
-export default function FunctionNode({ data, selected }: NodeProps<FunctionFlowNode>) {
+export default function FileNode({ data, selected }: NodeProps<FileFlowNode>) {
   return (
     <div
       className={[
         'relative overflow-hidden rounded-[6px] border border-stone-200 bg-white text-left shadow-sm',
-        'w-[200px]',
+        'w-[220px]',
         selected ? 'ring-2 ring-stone-900' : '',
         !selected && data.changed ? 'ring-2 ring-amber-400' : '',
       ]
@@ -20,12 +20,15 @@ export default function FunctionNode({ data, selected }: NodeProps<FunctionFlowN
       {data.changed && (
         <div className="absolute right-1.5 top-1.5 size-2 rounded-full bg-amber-400" />
       )}
-      <div className="pl-3 pr-4 py-2">
-        <p className="truncate text-xs font-semibold text-stone-900">{data.label}</p>
+      <div className="pl-3 pr-4 py-2 space-y-0.5">
+        <p className="truncate text-xs font-semibold text-stone-900">{data.fileName}</p>
         <p className="truncate font-mono text-[10px] text-stone-400">{data.packagePath}</p>
-        <p className="truncate font-mono text-[10px] text-stone-300">
-          {data.file.split('/').pop()}:{data.line}
-        </p>
+        <div className="flex gap-2 font-mono text-[10px] text-stone-400">
+          <span>{data.functionCount} fns</span>
+          {data.changedCount > 0 && (
+            <span className="text-amber-500">{data.changedCount} changed</span>
+          )}
+        </div>
       </div>
       <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
       <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />

--- a/frontend/src/components/graph/FunctionDetailsPanel.tsx
+++ b/frontend/src/components/graph/FunctionDetailsPanel.tsx
@@ -1,0 +1,101 @@
+import type { AnyFlowNode, LayerKind } from '@/types/graph'
+import type { Cluster } from '@/types/api'
+import { getClusterColor } from '@/lib/clusterColors'
+
+const LAYER_LABELS: Record<LayerKind, string> = {
+  ui: 'UI',
+  domain: 'Domain',
+  data: 'Data',
+  infra: 'Infra',
+  other: 'Other',
+}
+
+type Props = {
+  node: AnyFlowNode | null
+  cluster: Cluster | null
+  layer: LayerKind
+  onClose: () => void
+}
+
+export default function FunctionDetailsPanel({ node, cluster, layer, onClose }: Props) {
+  if (!node || (node.type !== 'function' && node.type !== 'file')) return null
+
+  const color = cluster ? getClusterColor(cluster.id) : null
+  const changed = node.data.changed as boolean
+
+  return (
+    <div className="flex w-80 flex-shrink-0 flex-col border-l border-stone-200 bg-white overflow-auto">
+      <div className="flex items-center justify-between border-b border-stone-100 px-4 py-3">
+        <span className="text-sm font-semibold text-stone-800">詳細</span>
+        <button
+          onClick={onClose}
+          className="rounded p-1 text-stone-400 hover:bg-stone-100 hover:text-stone-600"
+          aria-label="閉じる"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 14 14"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <path d="M2 2l10 10M12 2L2 12" />
+          </svg>
+        </button>
+      </div>
+
+      <div className="p-4 space-y-4">
+        <div className="flex flex-wrap gap-1.5">
+          {cluster && color && (
+            <span
+              className="rounded-full px-2 py-0.5 text-xs font-medium"
+              style={{ background: color.soft, color: color.ink }}
+            >
+              {cluster.label}
+            </span>
+          )}
+          <span className="rounded-full bg-stone-100 px-2 py-0.5 text-xs font-medium text-stone-600">
+            {LAYER_LABELS[layer]}
+          </span>
+          {changed && (
+            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
+              changed
+            </span>
+          )}
+        </div>
+
+        {node.type === 'function' && (
+          <>
+            <div>
+              <p className="break-all text-base font-bold text-stone-900">{node.data.label}</p>
+              <p className="mt-1 break-all font-mono text-xs text-stone-500">
+                {node.data.packagePath}
+              </p>
+            </div>
+            <p className="font-mono text-xs text-stone-400">
+              {node.data.file.split('/').pop()}:{node.data.line}
+            </p>
+          </>
+        )}
+
+        {node.type === 'file' && (
+          <>
+            <div>
+              <p className="break-all text-base font-bold text-stone-900">{node.data.fileName}</p>
+              <p className="mt-1 break-all font-mono text-xs text-stone-500">
+                {node.data.packagePath}
+              </p>
+            </div>
+            <div className="space-y-1 text-sm text-stone-600">
+              <p>{node.data.functionCount} 関数</p>
+              {node.data.changedCount > 0 && (
+                <p className="text-amber-600">{node.data.changedCount} 件変更あり</p>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/graph/GraphControls.tsx
+++ b/frontend/src/components/graph/GraphControls.tsx
@@ -1,4 +1,45 @@
-// TODO: ズーム・フィット・フィルター操作パネル
-export default function GraphControls() {
-  return <div>GraphControls</div>
+import type { NodeKind } from '@/types/graph'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+
+type Props = {
+  nodeKind: NodeKind
+  onChangeNodeKind: (kind: NodeKind) => void
+  onFitChanged: () => void
+}
+
+export default function GraphControls({ nodeKind, onChangeNodeKind, onFitChanged }: Props) {
+  return (
+    <Card className="shadow-md border-stone-200 bg-white">
+      <CardContent className="p-2 flex flex-col gap-2">
+        <div className="flex overflow-hidden rounded border border-stone-200 text-xs">
+          <button
+            className={[
+              'px-3 py-1.5 transition-colors',
+              nodeKind === 'function'
+                ? 'bg-stone-900 text-white'
+                : 'bg-white text-stone-600 hover:bg-stone-50',
+            ].join(' ')}
+            onClick={() => onChangeNodeKind('function')}
+          >
+            関数
+          </button>
+          <button
+            className={[
+              'border-l border-stone-200 px-3 py-1.5 transition-colors',
+              nodeKind === 'file'
+                ? 'bg-stone-900 text-white'
+                : 'bg-white text-stone-600 hover:bg-stone-50',
+            ].join(' ')}
+            onClick={() => onChangeNodeKind('file')}
+          >
+            ファイル
+          </button>
+        </div>
+        <Button variant="outline" size="sm" className="h-7 w-full text-xs" onClick={onFitChanged}>
+          変更ノードに寄せる
+        </Button>
+      </CardContent>
+    </Card>
+  )
 }

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,4 +1,17 @@
-// TODO: ヘッダー・サイドバー・メインエリアのページ骨格
-export default function AppShell({ children }: { children: React.ReactNode }) {
-  return <div>{children}</div>
+type Props = {
+  topBar: React.ReactNode
+  children: React.ReactNode
+  rightPanel?: React.ReactNode
+}
+
+export default function AppShell({ topBar, children, rightPanel }: Props) {
+  return (
+    <div className="grid h-svh grid-rows-[auto_1fr] overflow-hidden">
+      {topBar}
+      <div className="flex min-h-0">
+        <div className="relative min-h-0 flex-1">{children}</div>
+        {rightPanel}
+      </div>
+    </div>
+  )
 }

--- a/frontend/src/components/layout/PRMetaBar.tsx
+++ b/frontend/src/components/layout/PRMetaBar.tsx
@@ -1,0 +1,42 @@
+import { Button } from '@/components/ui/button'
+import { useAuth, useLogout } from '@/hooks/useAuth'
+import Brand from '@/components/branding/Brand'
+import type { PRInfo } from '@/types/api'
+
+type Props = { pr: PRInfo }
+
+export default function PRMetaBar({ pr }: Props) {
+  const { user } = useAuth()
+  const logout = useLogout()
+
+  return (
+    <header className="flex h-12 flex-shrink-0 items-center gap-3 border-b border-stone-200 bg-white px-4">
+      <Brand size={14} />
+      <div className="h-5 w-px bg-stone-200" />
+      <div className="min-w-0 flex-1">
+        <span className="text-sm font-medium text-stone-800">{pr.title || `PR #${pr.number}`}</span>
+        <span className="ml-2 font-mono text-xs text-stone-400">
+          {pr.owner}/{pr.repo} #{pr.number}
+          {pr.head_ref && pr.base_ref && (
+            <>
+              {' '}
+              · {pr.head_ref} → {pr.base_ref}
+            </>
+          )}
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        {user && <span className="text-xs text-stone-400">{user.login}</span>}
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 text-xs"
+          onClick={() => logout.mutate()}
+          disabled={logout.isPending}
+        >
+          ログアウト
+        </Button>
+      </div>
+    </header>
+  )
+}

--- a/frontend/src/hooks/useGraph.ts
+++ b/frontend/src/hooks/useGraph.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from '@/lib/api'
+import type { GraphResponse } from '@/types/api'
+
+export function useGraph(jobId: string, enabled: boolean) {
+  return useQuery<GraphResponse>({
+    queryKey: ['graph', jobId],
+    queryFn: () => apiFetch<GraphResponse>(`/api/graph/${jobId}`),
+    enabled,
+    staleTime: Infinity,
+    retry: false,
+  })
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7,7 +7,14 @@
 
 @theme inline {
   --font-heading: var(--font-sans);
-  --font-sans: 'Geist Variable', sans-serif;
+  --font-sans: 'Inter Tight', 'Geist Variable', sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+  --color-brand: #0f766e;
+  --color-brand-soft: #ccfbf1;
+  --color-bg: #fafaf9;
+  --color-ink: #1c1917;
+  --color-ink-2: #44403c;
+  --color-ink-3: #78716c;
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/frontend/src/lib/clusterColors.ts
+++ b/frontend/src/lib/clusterColors.ts
@@ -1,0 +1,16 @@
+const PALETTE = [
+  { hex: '#0d9488', soft: '#ccfbf1', ink: '#134e4a' }, // teal
+  { hex: '#4f46e5', soft: '#e0e7ff', ink: '#1e1b4b' }, // indigo
+  { hex: '#d97706', soft: '#fef3c7', ink: '#451a03' }, // amber
+  { hex: '#e11d48', soft: '#ffe4e6', ink: '#4c0519' }, // rose
+  { hex: '#059669', soft: '#d1fae5', ink: '#064e3b' }, // emerald
+  { hex: '#0284c7', soft: '#e0f2fe', ink: '#0c4a6e' }, // sky
+  { hex: '#a21caf', soft: '#fae8ff', ink: '#581c87' }, // fuchsia
+  { hex: '#65a30d', soft: '#ecfccb', ink: '#1a2e05' }, // lime
+] as const
+
+export type ClusterColor = { hex: string; soft: string; ink: string }
+
+export function getClusterColor(clusterId: number): ClusterColor {
+  return PALETTE[((clusterId % PALETTE.length) + PALETTE.length) % PALETTE.length]
+}

--- a/frontend/src/lib/fileAggregation.ts
+++ b/frontend/src/lib/fileAggregation.ts
@@ -1,0 +1,108 @@
+import type { GraphResponse, GraphEdge, Cluster } from '@/types/api'
+
+export type AggregatedFileNode = {
+  id: string
+  name: string
+  package: string
+  file: string
+  line: number
+  changed: boolean
+  functionCount: number
+  changedCount: number
+}
+
+export type FileAggResult = {
+  nodes: AggregatedFileNode[]
+  edges: GraphEdge[]
+  clusters: Cluster[]
+}
+
+export function aggregateByFile(data: GraphResponse): FileAggResult {
+  const { graph, clusters } = data
+
+  const nodeToCluster = new Map<string, number>()
+  for (const c of clusters) {
+    for (const nid of c.nodes) nodeToCluster.set(nid, c.id)
+  }
+
+  // Group function nodes by file path
+  const fileGroups = new Map<string, typeof graph.nodes>()
+  for (const n of graph.nodes) {
+    const fileKey = n.file || n.package
+    const arr = fileGroups.get(fileKey)
+    if (arr) arr.push(n)
+    else fileGroups.set(fileKey, [n])
+  }
+
+  const nodeToFileId = new Map<string, string>()
+  const fileNodes: AggregatedFileNode[] = []
+
+  for (const [file, nodes] of fileGroups.entries()) {
+    const fileNodeId = `file:${file}`
+    for (const n of nodes) nodeToFileId.set(n.id, fileNodeId)
+
+    const changedCount = nodes.filter((n) => n.changed).length
+    const pkg = nodes[0]?.package ?? ''
+    const fileName = file.split('/').pop() ?? file
+
+    fileNodes.push({
+      id: fileNodeId,
+      name: fileName,
+      package: pkg,
+      file,
+      line: 0,
+      changed: changedCount > 0,
+      functionCount: nodes.length,
+      changedCount,
+    })
+  }
+
+  // Deduplicate inter-file edges
+  const edgeSet = new Set<string>()
+  const fileEdges: GraphEdge[] = []
+  for (const e of graph.edges) {
+    const fromFile = nodeToFileId.get(e.from)
+    const toFile = nodeToFileId.get(e.to)
+    if (!fromFile || !toFile || fromFile === toFile) continue
+    const key = `${fromFile}->${toFile}`
+    if (edgeSet.has(key)) continue
+    edgeSet.add(key)
+    fileEdges.push({ from: fromFile, to: toFile })
+  }
+
+  // Assign each file node to the dominant cluster of its functions
+  const fileNodeClusterFreq = new Map<string, Map<number, number>>()
+  for (const n of graph.nodes) {
+    const fileNodeId = nodeToFileId.get(n.id)
+    if (!fileNodeId) continue
+    const cid = nodeToCluster.get(n.id) ?? 0
+    if (!fileNodeClusterFreq.has(fileNodeId)) fileNodeClusterFreq.set(fileNodeId, new Map())
+    const freq = fileNodeClusterFreq.get(fileNodeId)!
+    freq.set(cid, (freq.get(cid) ?? 0) + 1)
+  }
+
+  const newClusterMembers = new Map<number, string[]>()
+  for (const [fileNodeId, freq] of fileNodeClusterFreq.entries()) {
+    let dominantCid = 0
+    let maxCount = 0
+    for (const [cid, count] of freq.entries()) {
+      if (count > maxCount) {
+        maxCount = count
+        dominantCid = cid
+      }
+    }
+    const arr = newClusterMembers.get(dominantCid)
+    if (arr) arr.push(fileNodeId)
+    else newClusterMembers.set(dominantCid, [fileNodeId])
+  }
+
+  const fileClusters: Cluster[] = []
+  for (const origCluster of clusters) {
+    const members = newClusterMembers.get(origCluster.id)
+    if (members && members.length > 0) {
+      fileClusters.push({ id: origCluster.id, label: origCluster.label, nodes: members })
+    }
+  }
+
+  return { nodes: fileNodes, edges: fileEdges, clusters: fileClusters }
+}

--- a/frontend/src/lib/graphLayout.ts
+++ b/frontend/src/lib/graphLayout.ts
@@ -1,0 +1,184 @@
+import type { Edge } from '@xyflow/react'
+import type { GraphResponse, Cluster, GraphEdge } from '@/types/api'
+import type {
+  AnyFlowNode,
+  NodeKind,
+  LayerKind,
+  FunctionNodeData,
+  FileNodeData,
+  ClusterGroupData,
+} from '@/types/graph'
+import { getClusterColor } from './clusterColors'
+import { inferLayer } from './layerInference'
+import { aggregateByFile, type AggregatedFileNode } from './fileAggregation'
+
+const LAYER_ORDER: LayerKind[] = ['ui', 'domain', 'data', 'infra', 'other']
+
+const NODE_W = 200
+const NODE_H = 60
+const COLS = 5
+const COL_STRIDE = 220
+const ROW_STRIDE = 140
+const PADDING = 24
+const CLUSTER_LABEL_H = 28
+const CLUSTER_GAP = 48
+const LAYER_GAP = 64
+
+type InputNode = {
+  id: string
+  name: string
+  package: string
+  file: string
+  line: number
+  changed: boolean
+  functionCount: number
+  changedCount: number
+}
+
+export type LayoutResult = { nodes: AnyFlowNode[]; edges: Edge[] }
+
+export function layoutGraph(data: GraphResponse, nodeKind: NodeKind): LayoutResult {
+  let inputNodes: InputNode[]
+  let inputEdges: GraphEdge[]
+  let clusters: Cluster[]
+
+  if (nodeKind === 'file') {
+    const agg = aggregateByFile(data)
+    inputNodes = agg.nodes
+    inputEdges = agg.edges
+    clusters = agg.clusters
+  } else {
+    inputNodes = data.graph.nodes.map((n) => ({
+      ...n,
+      functionCount: 1,
+      changedCount: n.changed ? 1 : 0,
+    }))
+    inputEdges = data.graph.edges
+    clusters = data.clusters
+  }
+
+  const nodeToCluster = new Map<string, number>()
+  for (const c of clusters) {
+    for (const nid of c.nodes) nodeToCluster.set(nid, c.id)
+  }
+
+  // Group nodes by (layer, clusterId)
+  const groups = new Map<string, InputNode[]>()
+  for (const n of inputNodes) {
+    const layer = inferLayer(n.package)
+    const cid = nodeToCluster.get(n.id) ?? 0
+    const key = `${layer}:${cid}`
+    if (!groups.has(key)) groups.set(key, [])
+    groups.get(key)!.push(n)
+  }
+
+  const flowNodes: AnyFlowNode[] = []
+  const flowEdges: Edge[] = inputEdges.map((e) => ({
+    id: `e:${e.from}->${e.to}`,
+    source: e.from,
+    target: e.to,
+    style: { stroke: '#d6d3d1', strokeWidth: 1.5 },
+  }))
+
+  let layerY = 0
+
+  for (const layer of LAYER_ORDER) {
+    const layerGroups: Array<{ cid: number; nodes: InputNode[] }> = []
+    for (const [key, nodes] of groups.entries()) {
+      const colonIdx = key.indexOf(':')
+      const l = key.slice(0, colonIdx)
+      const cidStr = key.slice(colonIdx + 1)
+      if (l === layer) {
+        layerGroups.push({ cid: Number(cidStr), nodes })
+      }
+    }
+    if (layerGroups.length === 0) continue
+
+    let clusterX = 0
+    let maxClusterH = 0
+
+    for (const { cid, nodes } of layerGroups) {
+      const color = getClusterColor(cid)
+      const clusterLabel = clusters.find((c) => c.id === cid)?.label ?? `Cluster ${cid}`
+
+      const rows = Math.ceil(nodes.length / COLS)
+      const actualCols = Math.min(nodes.length, COLS)
+      const clusterW = PADDING * 2 + (actualCols - 1) * COL_STRIDE + NODE_W
+      const clusterH =
+        PADDING * 2 + CLUSTER_LABEL_H + rows * NODE_H + (rows - 1) * (ROW_STRIDE - NODE_H)
+
+      const clusterId = `cluster:${layer}:${cid}`
+
+      flowNodes.push({
+        id: clusterId,
+        type: 'cluster',
+        position: { x: clusterX, y: layerY },
+        data: {
+          label: clusterLabel,
+          clusterId: cid,
+          clusterColorHex: color.hex,
+          clusterColorSoft: color.soft,
+        } as ClusterGroupData,
+        style: { width: clusterW, height: clusterH },
+        draggable: false,
+        selectable: false,
+        zIndex: 0,
+      })
+
+      nodes.forEach((n, i) => {
+        const col = i % COLS
+        const row = Math.floor(i / COLS)
+        const x = PADDING + col * COL_STRIDE
+        const y = PADDING + CLUSTER_LABEL_H + row * ROW_STRIDE
+
+        if (nodeKind === 'file') {
+          const fn = n as AggregatedFileNode
+          flowNodes.push({
+            id: n.id,
+            type: 'file',
+            parentId: clusterId,
+            extent: 'parent',
+            position: { x, y },
+            zIndex: 1,
+            data: {
+              fileName: fn.name,
+              packagePath: fn.package,
+              functionCount: fn.functionCount,
+              changedCount: fn.changedCount,
+              changed: fn.changed,
+              clusterId: cid,
+              clusterColorHex: color.hex,
+              layer,
+            } as FileNodeData,
+          })
+        } else {
+          flowNodes.push({
+            id: n.id,
+            type: 'function',
+            parentId: clusterId,
+            extent: 'parent',
+            position: { x, y },
+            zIndex: 1,
+            data: {
+              label: n.name,
+              packagePath: n.package,
+              file: n.file,
+              line: n.line,
+              changed: n.changed,
+              clusterId: cid,
+              clusterColorHex: color.hex,
+              layer,
+            } as FunctionNodeData,
+          })
+        }
+      })
+
+      clusterX += clusterW + CLUSTER_GAP
+      maxClusterH = Math.max(maxClusterH, clusterH)
+    }
+
+    layerY += maxClusterH + LAYER_GAP
+  }
+
+  return { nodes: flowNodes, edges: flowEdges }
+}

--- a/frontend/src/lib/layerInference.ts
+++ b/frontend/src/lib/layerInference.ts
@@ -1,0 +1,15 @@
+import type { LayerKind } from '@/types/graph'
+
+export function inferLayer(packagePath: string): LayerKind {
+  if (
+    packagePath.includes('internal/api') ||
+    packagePath.includes('cmd/') ||
+    packagePath.includes('frontend/')
+  )
+    return 'ui'
+  if (packagePath.includes('internal/usecase') || packagePath.includes('internal/domain'))
+    return 'domain'
+  if (packagePath.includes('internal/infra')) return 'infra'
+  if (packagePath.includes('internal/pkg') || packagePath.includes('pkg/')) return 'data'
+  return 'other'
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,3 +1,4 @@
+import '@xyflow/react/dist/style.css'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'

--- a/frontend/src/pages/Analysis.tsx
+++ b/frontend/src/pages/Analysis.tsx
@@ -3,6 +3,7 @@ import { useParams, Link } from 'react-router-dom'
 import { useJobStatus } from '@/hooks/useJobStatus'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import AnalysisGraphView from '@/pages/AnalysisGraphView'
 
 const STEPS = [
   'リポジトリのクローン',
@@ -80,19 +81,7 @@ export default function Analysis() {
   }
 
   if (job.status === 'done') {
-    return (
-      <div className="flex min-h-svh items-center justify-center bg-[#fafaf9]">
-        <Card className="w-full max-w-md border-teal-200">
-          <CardContent className="pt-6 space-y-3">
-            <div className="flex items-center gap-2 text-teal-600 font-semibold">
-              <CheckCircleIcon />
-              <span>解析が完了しました</span>
-            </div>
-            <p className="text-sm text-stone-500">グラフビューは次のリリースで実装予定です。</p>
-          </CardContent>
-        </Card>
-      </div>
-    )
+    return <AnalysisGraphView jobId={jobId ?? ''} />
   }
 
   return (
@@ -194,22 +183,6 @@ function SpinnerIcon() {
       className="animate-spin"
     >
       <circle cx="10" cy="10" r="7" strokeDasharray="32" strokeDashoffset="8" />
-    </svg>
-  )
-}
-
-function CheckCircleIcon() {
-  return (
-    <svg
-      width="18"
-      height="18"
-      viewBox="0 0 18 18"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-    >
-      <circle cx="9" cy="9" r="7" />
-      <path d="M5.5 9l2.5 2.5 4.5-4.5" />
     </svg>
   )
 }

--- a/frontend/src/pages/AnalysisGraphView.tsx
+++ b/frontend/src/pages/AnalysisGraphView.tsx
@@ -1,0 +1,172 @@
+import { useMemo, useState, useCallback } from 'react'
+import { Link } from 'react-router-dom'
+import type { NodeKind, LayerKind, AnyFlowNode } from '@/types/graph'
+import type { Cluster } from '@/types/api'
+import { useGraph } from '@/hooks/useGraph'
+import { inferLayer } from '@/lib/layerInference'
+import { getClusterColor } from '@/lib/clusterColors'
+import AppShell from '@/components/layout/AppShell'
+import PRMetaBar from '@/components/layout/PRMetaBar'
+import DependencyGraph from '@/components/graph/DependencyGraph'
+import FunctionDetailsPanel from '@/components/graph/FunctionDetailsPanel'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+type Props = { jobId: string }
+
+export default function AnalysisGraphView({ jobId }: Props) {
+  const { data, isLoading, error } = useGraph(jobId, true)
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
+  const [nodeKind, setNodeKind] = useState<NodeKind>('function')
+
+  const handleChangeNodeKind = useCallback((kind: NodeKind) => {
+    setNodeKind(kind)
+    setSelectedNodeId(null)
+  }, [])
+
+  const { panelNode, selectedCluster, selectedLayer } = useMemo(() => {
+    if (!data || !selectedNodeId) {
+      return { panelNode: null, selectedCluster: null, selectedLayer: 'other' as LayerKind }
+    }
+
+    // File node selected (file mode)
+    if (selectedNodeId.startsWith('file:')) {
+      const filePath = selectedNodeId.slice(5)
+      const fileNodes = data.graph.nodes.filter((n) => n.file === filePath)
+      if (fileNodes.length === 0) {
+        return { panelNode: null, selectedCluster: null, selectedLayer: 'other' as LayerKind }
+      }
+      const pkg = fileNodes[0].package
+      const layer = inferLayer(pkg)
+      const changedCount = fileNodes.filter((n) => n.changed).length
+
+      const clusterFreq = new Map<number, number>()
+      for (const n of fileNodes) {
+        const c = data.clusters.find((c) => c.nodes.includes(n.id))
+        if (c) clusterFreq.set(c.id, (clusterFreq.get(c.id) ?? 0) + 1)
+      }
+      let domCid = 0
+      let maxFreq = 0
+      for (const [cid, freq] of clusterFreq.entries()) {
+        if (freq > maxFreq) {
+          maxFreq = freq
+          domCid = cid
+        }
+      }
+      const cluster = data.clusters.find((c) => c.id === domCid) ?? null
+      const color = getClusterColor(domCid)
+
+      const node: AnyFlowNode = {
+        id: selectedNodeId,
+        type: 'file',
+        position: { x: 0, y: 0 },
+        data: {
+          fileName: filePath.split('/').pop() ?? filePath,
+          packagePath: pkg,
+          functionCount: fileNodes.length,
+          changedCount,
+          changed: changedCount > 0,
+          clusterId: domCid,
+          clusterColorHex: color.hex,
+          layer,
+        },
+      }
+      return { panelNode: node, selectedCluster: cluster, selectedLayer: layer }
+    }
+
+    // Function node selected
+    const gn = data.graph.nodes.find((n) => n.id === selectedNodeId)
+    if (!gn) return { panelNode: null, selectedCluster: null, selectedLayer: 'other' as LayerKind }
+
+    const layer = inferLayer(gn.package)
+    const cluster: Cluster | null = data.clusters.find((c) => c.nodes.includes(gn.id)) ?? null
+    const cid = cluster?.id ?? 0
+    const color = getClusterColor(cid)
+
+    const node: AnyFlowNode = {
+      id: gn.id,
+      type: 'function',
+      position: { x: 0, y: 0 },
+      data: {
+        label: gn.name,
+        packagePath: gn.package,
+        file: gn.file,
+        line: gn.line,
+        changed: gn.changed,
+        clusterId: cid,
+        clusterColorHex: color.hex,
+        layer,
+      },
+    }
+    return { panelNode: node, selectedCluster: cluster, selectedLayer: layer }
+  }, [data, selectedNodeId])
+
+  if (isLoading) {
+    return (
+      <div className="flex h-svh items-center justify-center bg-[#fafaf9]">
+        <LoadingSpinner />
+      </div>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <div className="flex h-svh items-center justify-center bg-[#fafaf9]">
+        <Card className="w-full max-w-md border-red-200">
+          <CardContent className="space-y-3 pt-6">
+            <p className="text-sm font-semibold text-red-600">グラフの読み込みに失敗しました</p>
+            <p className="text-xs text-stone-500">
+              {error instanceof Error ? error.message : '不明なエラー'}
+            </p>
+            <Button asChild variant="outline" size="sm">
+              <Link to="/">ホームへ戻る</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <AppShell
+      topBar={<PRMetaBar pr={data.pr} />}
+      rightPanel={
+        panelNode ? (
+          <FunctionDetailsPanel
+            node={panelNode}
+            cluster={selectedCluster}
+            layer={selectedLayer}
+            onClose={() => setSelectedNodeId(null)}
+          />
+        ) : undefined
+      }
+    >
+      <DependencyGraph
+        data={data}
+        nodeKind={nodeKind}
+        onChangeNodeKind={handleChangeNodeKind}
+        selectedNodeId={selectedNodeId}
+        onSelectNode={setSelectedNodeId}
+      />
+    </AppShell>
+  )
+}
+
+function LoadingSpinner() {
+  return (
+    <div className="flex items-center gap-3 text-stone-400">
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 20 20"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        className="animate-spin"
+      >
+        <circle cx="10" cy="10" r="7" strokeDasharray="32" strokeDashoffset="8" />
+      </svg>
+      <span className="text-sm">グラフを読み込み中…</span>
+    </div>
+  )
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,43 +1,37 @@
-// TODO: バックエンド API レスポンスの TypeScript 型定義
-
-export interface JobResponse {
+export type JobResponse = {
   job_id: string
   status: 'pending' | 'running' | 'done' | 'error'
   analysis_id?: string
   error?: string
 }
 
-export interface AnalysisResponse {
-  id: string
-  pr: PRInfo
-  result: ClusterResult
-  created_at: string
-}
-
-export interface PRInfo {
+export type PRInfo = {
   owner: string
   repo: string
   number: number
   title: string
+  base_ref: string
+  head_ref: string
 }
 
-export interface ClusterResult {
+export type GraphResponse = {
+  pr: PRInfo
   clusters: Cluster[]
   graph: Graph
 }
 
-export interface Cluster {
+export type Cluster = {
   id: number
   label: string
-  node_ids: string[]
+  nodes: string[]
 }
 
-export interface Graph {
+export type Graph = {
   nodes: GraphNode[]
   edges: GraphEdge[]
 }
 
-export interface GraphNode {
+export type GraphNode = {
   id: string
   name: string
   package: string
@@ -46,7 +40,7 @@ export interface GraphNode {
   changed: boolean
 }
 
-export interface GraphEdge {
+export type GraphEdge = {
   from: string
   to: string
 }

--- a/frontend/src/types/cluster.ts
+++ b/frontend/src/types/cluster.ts
@@ -1,1 +1,6 @@
-// TODO: クラスタ関連の型定義
+export type ClusterMeta = {
+  id: number
+  label: string
+  nodeCount: number
+  colorIndex: number
+}

--- a/frontend/src/types/graph.ts
+++ b/frontend/src/types/graph.ts
@@ -1,1 +1,42 @@
-// TODO: @xyflow/react 用のノード・エッジ型定義
+import type { Node } from '@xyflow/react'
+
+export type NodeKind = 'function' | 'file'
+export type LayerKind = 'ui' | 'domain' | 'data' | 'infra' | 'other'
+
+export type FunctionNodeData = {
+  label: string
+  packagePath: string
+  file: string
+  line: number
+  changed: boolean
+  clusterId: number
+  clusterColorHex: string
+  layer: LayerKind
+  [key: string]: unknown
+}
+
+export type FileNodeData = {
+  fileName: string
+  packagePath: string
+  functionCount: number
+  changedCount: number
+  changed: boolean
+  clusterId: number
+  clusterColorHex: string
+  layer: LayerKind
+  [key: string]: unknown
+}
+
+export type ClusterGroupData = {
+  label: string
+  clusterId: number
+  clusterColorHex: string
+  clusterColorSoft: string
+  [key: string]: unknown
+}
+
+export type FunctionFlowNode = Node<FunctionNodeData, 'function'>
+export type FileFlowNode = Node<FileNodeData, 'file'>
+export type ClusterFlowNode = Node<ClusterGroupData, 'cluster'>
+
+export type AnyFlowNode = FunctionFlowNode | FileFlowNode | ClusterFlowNode


### PR DESCRIPTION
## Summary

- **issue #10**: PR 依存グラフの可視化 UI を実装。ReactFlow (@xyflow/react) でコールグラフをインタラクティブに表示し、関数ノード / ファイル集約モードの切り替え、クラスタ色分け、詳細パネルを提供する
- **issue #39**: 解析グラフに外部ライブラリが混入する問題を修正。2フェーズロード（FastLoad → 近傍ターゲットロード）と `pkg.Module.Main` フィルタにより、自リポジトリパッケージのみを解析対象にする

### issue #10: グラフ可視化
- `GET /api/graph/:jobId` レスポンスに PR メタ情報 (`PRInfoDTO`) を追加
- フロントエンド型定義 (`api.ts` / `graph.ts` / `cluster.ts`) を整備
- グラフレイアウト・色分け・レイヤー推定ユーティリティを実装
- `useGraph` フック・デザイントークン・@xyflow/react CSS を追加
- ノード/エッジ/パネル等のグラフ描画コンポーネント群を実装
- `AnalysisGraphView` ページでジョブ完了後にグラフを表示

### issue #39: 外部パッケージ除外
- **Phase 1**: `FastLoad`（型チェックなし）で全パッケージ構造を高速取得
- **Phase 2**: 変更パッケージの近傍（3ホップ以内）のみを型情報付きロード
- `callgraph.Build` で `pkg.Module.Main=true` のプロジェクト内パッケージのみ SSA 対象にする
- 解析サイズが ~36MB → ~数KB に削減、処理時間が ~5分 → ~35秒 に短縮
- 再起動時に pending/running のまま残るジョブを error に更新する `MarkStaleJobsError` を追加
- 解析パイプライン計測用の `bench` コマンドを追加

## Test plan

- [ ] GitHub OAuth でログインできる
- [ ] PR URL を入力して「解析中」ステップ画面が表示される
- [ ] ジョブが完了するとグラフ画面に自動遷移する
- [ ] グラフに外部パッケージ（`modernc.org/*` 等）が含まれていない
- [ ] 関数ノード / ファイル集約モードが切り替わる
- [ ] ノードをクリックすると詳細パネルが開く
- [ ] サーバ再起動後、以前の running ジョブが error になっている