### PR TITLE
fix: グラフノードのファイルパスが /tmp/... になっている (#41)

### DIFF
--- a/backend/cmd/bench/main.go
+++ b/backend/cmd/bench/main.go
@@ -66,7 +66,7 @@ func main() {
 	// 4. コールグラフ構築
 	t3 := time.Now()
 	cgBuilder := analyzer.NewGoCallGraphBuilder()
-	graph, err := cgBuilder.Build(ctx, prepared.Packages, prepared.ChangedPackages, prepared.ChangedFileAbsPaths)
+	graph, err := cgBuilder.Build(ctx, prepared.Packages, prepared.ChangedPackages, prepared.ChangedFileAbsPaths, prepared.RootDir)
 	if err != nil {
 		log.Fatalf("Build: %v", err)
 	}

--- a/backend/internal/infra/analyzer/callgraph.go
+++ b/backend/internal/infra/analyzer/callgraph.go
@@ -2,6 +2,7 @@ package analyzer
 
 import (
 	"context"
+	"strings"
 
 	"golang.org/x/tools/go/callgraph"
 	"golang.org/x/tools/go/callgraph/cha"
@@ -18,7 +19,7 @@ const defaultMaxDepth = 3
 // CallGraphBuilder はロード済みパッケージから呼び出しグラフを構築する抽象。
 // source_tree.go が返す PreparedSource.Packages / ChangedPackages / ChangedFileAbsPaths をそのまま渡せる設計にする。
 type CallGraphBuilder interface {
-	Build(ctx context.Context, pkgs []*packages.Package, changedPkgIDs []string, changedFileAbsPaths []string) (*domain.Graph, error)
+	Build(ctx context.Context, pkgs []*packages.Package, changedPkgIDs []string, changedFileAbsPaths []string, rootDir string) (*domain.Graph, error)
 }
 
 // GoCallGraphBuilder は golang.org/x/tools/go/callgraph を使う本番実装。
@@ -36,7 +37,8 @@ func NewGoCallGraphBuilder() *GoCallGraphBuilder {
 // changedPkgIDs が空の場合は空の Graph を返す。
 // changedFileAbsPaths は changed フラグをファイル単位で設定するために使う（パッケージ単位ではない）。
 // stdlib・外部ライブラリはフィルタリングして含めない。
-func (b *GoCallGraphBuilder) Build(_ context.Context, pkgs []*packages.Package, changedPkgIDs []string, changedFileAbsPaths []string) (*domain.Graph, error) {
+// リポジトリからの相対パスを生成するために、clone先のdirectoryを引数に設定した。
+func (b *GoCallGraphBuilder) Build(_ context.Context, pkgs []*packages.Package, changedPkgIDs []string, changedFileAbsPaths []string, rootDir string) (*domain.Graph, error) {
 	if len(changedPkgIDs) == 0 {
 		return &domain.Graph{}, nil
 	}
@@ -147,11 +149,12 @@ func (b *GoCallGraphBuilder) Build(_ context.Context, pkgs []*packages.Package, 
 
 		pos := prog.Fset.Position(fn.Pos())
 		_, fileChanged := changedFileSet[pos.Filename]
+		relPath := strings.TrimPrefix(pos.Filename, rootDir+"/") // リポジトリからの相対パスにする
 		nodes = append(nodes, domain.Node{
 			ID:      nid,
 			Name:    fn.Name(),
 			Package: pkgPath(fn),
-			File:    pos.Filename,
+			File:    relPath,
 			Line:    pos.Line,
 			Changed: fileChanged,
 		})

--- a/backend/internal/infra/analyzer/callgraph.go
+++ b/backend/internal/infra/analyzer/callgraph.go
@@ -2,7 +2,7 @@ package analyzer
 
 import (
 	"context"
-	"strings"
+	"path/filepath"
 
 	"golang.org/x/tools/go/callgraph"
 	"golang.org/x/tools/go/callgraph/cha"
@@ -37,7 +37,7 @@ func NewGoCallGraphBuilder() *GoCallGraphBuilder {
 // changedPkgIDs が空の場合は空の Graph を返す。
 // changedFileAbsPaths は changed フラグをファイル単位で設定するために使う（パッケージ単位ではない）。
 // stdlib・外部ライブラリはフィルタリングして含めない。
-// リポジトリからの相対パスを生成するために、clone先のdirectoryを引数に設定した。
+// rootDir はリポジトリのルートディレクトリの絶対パスで、ノードのファイルパスを相対パスに変換するために使用される。
 func (b *GoCallGraphBuilder) Build(_ context.Context, pkgs []*packages.Package, changedPkgIDs []string, changedFileAbsPaths []string, rootDir string) (*domain.Graph, error) {
 	if len(changedPkgIDs) == 0 {
 		return &domain.Graph{}, nil
@@ -149,7 +149,10 @@ func (b *GoCallGraphBuilder) Build(_ context.Context, pkgs []*packages.Package, 
 
 		pos := prog.Fset.Position(fn.Pos())
 		_, fileChanged := changedFileSet[pos.Filename]
-		relPath := strings.TrimPrefix(pos.Filename, rootDir+"/") // リポジトリからの相対パスにする
+		relPath, err := filepath.Rel(rootDir, pos.Filename) // リポジトリからの相対パスにする
+		if err != nil {
+			relPath = pos.Filename
+		}
 		nodes = append(nodes, domain.Node{
 			ID:      nid,
 			Name:    fn.Name(),

--- a/backend/internal/infra/analyzer/callgraph_test.go
+++ b/backend/internal/infra/analyzer/callgraph_test.go
@@ -78,9 +78,16 @@ func TestGoCallGraphBuilder_Build_ChangedNodes(t *testing.T) {
 	changedFileAbsPaths := []string{filepath.Join(root, "pkg/a/a.go")}
 
 	b := &GoCallGraphBuilder{MaxDepth: 3}
-	graph, err := b.Build(context.Background(), pkgs, []string{"example.com/cgfixture/pkg/a"}, changedFileAbsPaths)
+	graph, err := b.Build(context.Background(), pkgs, []string{"example.com/cgfixture/pkg/a"}, changedFileAbsPaths, root)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
+	}
+
+	// File フィールドが相対パスになっている（絶対パスでない）
+	for _, n := range graph.Nodes {
+		if filepath.IsAbs(n.File) {
+			t.Errorf("node %q: File should be relative, got %q", n.Name, n.File)
+		}
 	}
 
 	// 変更ファイル内の関数（A, C）は Changed=true
@@ -115,7 +122,7 @@ func TestGoCallGraphBuilder_Build_Edges(t *testing.T) {
 	pkgs := loadCGFixture(t, root)
 
 	b := &GoCallGraphBuilder{MaxDepth: 3}
-	graph, err := b.Build(context.Background(), pkgs, []string{"example.com/cgfixture/pkg/a"}, []string{filepath.Join(root, "pkg/a/a.go")})
+	graph, err := b.Build(context.Background(), pkgs, []string{"example.com/cgfixture/pkg/a"}, []string{filepath.Join(root, "pkg/a/a.go")}, root)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -152,7 +159,7 @@ func TestGoCallGraphBuilder_Build_StdlibExcluded(t *testing.T) {
 	pkgs := loadCGFixture(t, root)
 
 	b := &GoCallGraphBuilder{MaxDepth: 3}
-	graph, err := b.Build(context.Background(), pkgs, []string{"example.com/cgfixture/pkg/a"}, []string{filepath.Join(root, "pkg/a/a.go")})
+	graph, err := b.Build(context.Background(), pkgs, []string{"example.com/cgfixture/pkg/a"}, []string{filepath.Join(root, "pkg/a/a.go")}, root)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -170,7 +177,7 @@ func TestGoCallGraphBuilder_Build_EmptyChanged(t *testing.T) {
 	pkgs := loadCGFixture(t, root)
 
 	b := &GoCallGraphBuilder{MaxDepth: 3}
-	graph, err := b.Build(context.Background(), pkgs, []string{}, []string{})
+	graph, err := b.Build(context.Background(), pkgs, []string{}, []string{}, root)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}

--- a/backend/internal/infra/job/worker.go
+++ b/backend/internal/infra/job/worker.go
@@ -123,7 +123,7 @@ func (w *Worker) process(ctx context.Context, item Item) {
 	log.Printf("worker: Prepare (clone+load) took %s", time.Since(t1))
 
 	t2 := time.Now()
-	graph, err := w.cgBuilder.Build(ctx, prepared.Packages, prepared.ChangedPackages, prepared.ChangedFileAbsPaths)
+	graph, err := w.cgBuilder.Build(ctx, prepared.Packages, prepared.ChangedPackages, prepared.ChangedFileAbsPaths, prepared.RootDir)
 	if err != nil {
 		fail(fmt.Errorf("build callgraph: %w", err))
 		return

--- a/backend/internal/infra/job/worker_test.go
+++ b/backend/internal/infra/job/worker_test.go
@@ -111,7 +111,7 @@ type fakeCGBuilder struct {
 	err   error
 }
 
-func (b *fakeCGBuilder) Build(_ context.Context, _ []*packages.Package, _ []string, _ []string) (*domain.Graph, error) {
+func (b *fakeCGBuilder) Build(_ context.Context, _ []*packages.Package, _ []string, _ []string, _ string) (*domain.Graph, error) {
 	return b.graph, b.err
 }
 


### PR DESCRIPTION
## Summary

- `CallGraphBuilder.Build` に `rootDir string` 引数を追加
- `pos.Filename`（clone 先絶対パス）を `strings.TrimPrefix(pos.Filename, rootDir+"/")` でリポジトリ相対パスに変換
- `worker.go` で `prepared.RootDir` を渡すよう更新
- `worker_test.go` の `fakeCGBuilder` シグネチャを合わせて修正

## Test plan

- [ ] `docker compose run --rm backend go test ./...` が全パス
- [ ] `TestGoCallGraphBuilder_Build_ChangedNodes` で `File` フィールドが絶対パスでないことを確認するアサーションを追加済み

Closes #41