### PR TITLE
fix: モノレポ構成でグラフノードのFileパスがモジュールルート相対になりdiff突き合わせが外れる (#47)

### DIFF
--- a/backend/internal/infra/analyzer/source_tree.go
+++ b/backend/internal/infra/analyzer/source_tree.go
@@ -17,7 +17,8 @@ import (
 
 // PreparedSource はclone・ロード・変更パッケージ特定の結果をまとめたもの。
 type PreparedSource struct {
-	RootDir             string
+	RepoRoot            string // リポジトリルート（GitHub API パスの基点）
+	RootDir             string // go.mod のあるディレクトリ（パッケージロードの基点）
 	Packages            []*packages.Package
 	LoadErrors          []packages.Error
 	ChangedPackages     []string // パッケージID（重複なし・ソート済み）
@@ -91,6 +92,7 @@ func (s *SourceTree) Prepare(ctx context.Context, pr domain.PRInfo, token string
 	if len(changedPkgs) == 0 {
 		// 変更されたGoパッケージがない（非Goファイルのみの変更など）
 		return &PreparedSource{
+			RepoRoot:            clonedRoot,
 			RootDir:             loadDir,
 			ChangedPackages:     nil,
 			ChangedFileAbsPaths: changedFileAbsPaths,
@@ -113,6 +115,7 @@ func (s *SourceTree) Prepare(ctx context.Context, pr domain.PRInfo, token string
 	log.Printf("analyzer: phase2 Load(%d pkgs) took %s", len(result.Packages), time.Since(t1))
 
 	return &PreparedSource{
+		RepoRoot:            clonedRoot,
 		RootDir:             loadDir,
 		Packages:            result.Packages,
 		LoadErrors:          result.Errors,

--- a/backend/internal/infra/analyzer/source_tree_test.go
+++ b/backend/internal/infra/analyzer/source_tree_test.go
@@ -83,6 +83,9 @@ func G() int { return 42 }
 		t.Fatalf("Prepare: %v", err)
 	}
 
+	if ps.RepoRoot != resolvedDir {
+		t.Errorf("RepoRoot: got %q, want %q", ps.RepoRoot, resolvedDir)
+	}
 	if ps.RootDir != resolvedDir {
 		t.Errorf("RootDir: got %q, want %q", ps.RootDir, resolvedDir)
 	}
@@ -99,6 +102,46 @@ func G() int { return 42 }
 	}
 	if !fc.cleanupCalled {
 		t.Error("expected fakeCloner.Cleanup to be called")
+	}
+}
+
+func TestSourceTree_Prepare_MonorepoRepoRoot(t *testing.T) {
+	// fixture: go.mod がサブディレクトリ backend/ にあるモノレポ構成
+	dir := writeFixture(t, map[string]string{
+		"backend/go.mod": "module example.com/fixture\n\ngo 1.21\n",
+		"backend/pkg/a/a.go": `package a
+
+func F() int { return 42 }
+`,
+	})
+
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fc := &fakeCloner{fixtureDir: resolvedDir}
+	st := NewSourceTree(fc, NewGoPackageLoader())
+
+	pr := domain.PRInfo{Owner: "owner", Repo: "repo", HeadSHA: "abc123"}
+	changed := []domain.ChangedFile{
+		{Filename: "backend/pkg/a/a.go", Status: "modified"},
+	}
+
+	ps, err := st.Prepare(context.Background(), pr, "", changed)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	defer func() { _ = ps.Cleanup() }()
+
+	wantRepoRoot := resolvedDir
+	wantRootDir := filepath.Join(resolvedDir, "backend")
+
+	if ps.RepoRoot != wantRepoRoot {
+		t.Errorf("RepoRoot: got %q, want %q", ps.RepoRoot, wantRepoRoot)
+	}
+	if ps.RootDir != wantRootDir {
+		t.Errorf("RootDir: got %q, want %q", ps.RootDir, wantRootDir)
 	}
 }
 

--- a/backend/internal/infra/job/worker.go
+++ b/backend/internal/infra/job/worker.go
@@ -123,7 +123,7 @@ func (w *Worker) process(ctx context.Context, item Item) {
 	log.Printf("worker: Prepare (clone+load) took %s", time.Since(t1))
 
 	t2 := time.Now()
-	graph, err := w.cgBuilder.Build(ctx, prepared.Packages, prepared.ChangedPackages, prepared.ChangedFileAbsPaths, prepared.RootDir)
+	graph, err := w.cgBuilder.Build(ctx, prepared.Packages, prepared.ChangedPackages, prepared.ChangedFileAbsPaths, prepared.RepoRoot)
 	if err != nil {
 		fail(fmt.Errorf("build callgraph: %w", err))
 		return


### PR DESCRIPTION
## Summary

- `PreparedSource` に `RepoRoot`（クローンルート = GitHub API パスの基点）フィールドを追加
- `worker.go` で `cgBuilder.Build` に `prepared.RootDir`（loadDir）の代わりに `prepared.RepoRoot` を渡すよう変更
- モノレポ fixture（`go.mod` がサブディレクトリにある場合）の新規テスト `TestSourceTree_Prepare_MonorepoRepoRoot` を追加

## 問題の詳細

モノレポ構成（`go.mod` が `backend/` 配下）では `loadDir = <clone>/backend` となる。  
これまで `cgBuilder.Build` に `loadDir` を渡していたため、ノードの `File` が `internal/api/handler.go` のようなモジュールルート相対パスになっていた。  
GitHub API の `DiffFile.filename` はリポジトリルート相対（`backend/internal/api/handler.go`）なので突き合わせがマッチせず、`changed=true` でも「このファイルに変更はありません」と表示されていた。

## Test plan

- [ ] `docker compose run --rm backend go test ./...` が全パスすることを確認
- [ ] changed=true のノードをクリックしたとき diff が正しく表示されることを実環境で確認

closes #47