### PR TITLE
feat: クラスタ単位のノード集約（折りたたみ／展開）

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -146,6 +146,8 @@ ID やファイルパスは必ず mono にする。視認性と「これはコ�
 | `PRMetaBar` | 上部固定バー。PR タイトル・ブランチ情報・ユーザー情報 |
 | `DependencyGraph` | `@xyflow/react` ベースの呼び出しグラフ |
 | `FunctionNode` / `FileNode` | グラフ上のノード。`changed=true` で `ring-amber-400` |
+| `ClusterGroup` | 展開中クラスタの背景コンテナ。子ノードを `parentId` で内包 |
+| `SuperClusterNode` | 折りたたみ中クラスタのスーパーノード。クリックで展開 |
 | `FunctionDetailsPanel` | 右パネル。クラスタラベル・レイヤー・diff |
 | `DiffViewer` | `@monaco-editor/react` で before/after 表示 |
 | `ClusterSidebar` | クラスタ一覧（実装位置: `layout/`） |

--- a/frontend/src/components/graph/ClusterGroup.tsx
+++ b/frontend/src/components/graph/ClusterGroup.tsx
@@ -10,9 +10,16 @@ export default function ClusterGroup({ data }: NodeProps<ClusterFlowNode>) {
         border: `1.5px solid color-mix(in srgb, ${data.clusterColorHex} 35%, transparent)`,
       }}
     >
-      <div className="px-3 pt-2">
+      <div className="flex items-center justify-between px-3 pt-2">
         <span className="text-xs font-semibold" style={{ color: data.clusterColorHex }}>
           {data.label}
+        </span>
+        <span
+          className="cursor-pointer rounded px-1 text-[10px] text-stone-400 hover:text-stone-600"
+          title="折りたたむ"
+          aria-label="クラスタを折りたたむ"
+        >
+          −
         </span>
       </div>
     </div>

--- a/frontend/src/components/graph/DependencyGraph.tsx
+++ b/frontend/src/components/graph/DependencyGraph.tsx
@@ -15,6 +15,7 @@ import type { NodeKind } from '@/types/graph'
 import FunctionNode from './FunctionNode'
 import FileNode from './FileNode'
 import ClusterGroup from './ClusterGroup'
+import SuperClusterNode from './SuperClusterNode'
 import GraphControls from './GraphControls'
 import { layoutGraph } from '@/lib/graphLayout'
 
@@ -22,6 +23,7 @@ const nodeTypes = {
   function: FunctionNode,
   file: FileNode,
   cluster: ClusterGroup,
+  supercluster: SuperClusterNode,
 }
 
 type Props = {
@@ -30,12 +32,29 @@ type Props = {
   onChangeNodeKind: (kind: NodeKind) => void
   selectedNodeId: string | null
   onSelectNode: (id: string) => void
+  expandedClusters: Set<string>
+  onToggleCluster: (key: string) => void
+  onExpandAll: () => void
+  onCollapseAll: () => void
 }
 
-function GraphInner({ data, nodeKind, onChangeNodeKind, selectedNodeId, onSelectNode }: Props) {
+function GraphInner({
+  data,
+  nodeKind,
+  onChangeNodeKind,
+  selectedNodeId,
+  onSelectNode,
+  expandedClusters,
+  onToggleCluster,
+  onExpandAll,
+  onCollapseAll,
+}: Props) {
   const { fitView } = useReactFlow()
 
-  const { nodes: layoutNodes, edges } = useMemo(() => layoutGraph(data, nodeKind), [data, nodeKind])
+  const { nodes: layoutNodes, edges } = useMemo(
+    () => layoutGraph(data, nodeKind, expandedClusters),
+    [data, nodeKind, expandedClusters],
+  )
 
   const nodes = useMemo(
     () => layoutNodes.map((n) => ({ ...n, selected: n.id === selectedNodeId })),
@@ -44,11 +63,13 @@ function GraphInner({ data, nodeKind, onChangeNodeKind, selectedNodeId, onSelect
 
   const handleNodeClick: NodeMouseHandler = useCallback(
     (_, node) => {
-      if (node.type === 'function' || node.type === 'file') {
+      if (node.type === 'supercluster') {
+        onToggleCluster(node.data.clusterKey as string)
+      } else if (node.type === 'function' || node.type === 'file') {
         onSelectNode(node.id)
       }
     },
-    [onSelectNode],
+    [onSelectNode, onToggleCluster],
   )
 
   const handleFitChanged = useCallback(() => {
@@ -77,7 +98,9 @@ function GraphInner({ data, nodeKind, onChangeNodeKind, selectedNodeId, onSelect
       <Background variant={BackgroundVariant.Dots} gap={20} color="#e7e5e4" />
       <Controls position="bottom-left" />
       <MiniMap
-        nodeColor={(n) => (n.type === 'cluster' ? '#e7e5e4' : '#0d9488')}
+        nodeColor={(n) =>
+          n.type === 'cluster' || n.type === 'supercluster' ? '#e7e5e4' : '#0d9488'
+        }
         maskColor="rgba(250,250,249,0.6)"
       />
       <Panel position="bottom-right">
@@ -85,6 +108,8 @@ function GraphInner({ data, nodeKind, onChangeNodeKind, selectedNodeId, onSelect
           nodeKind={nodeKind}
           onChangeNodeKind={onChangeNodeKind}
           onFitChanged={handleFitChanged}
+          onExpandAll={onExpandAll}
+          onCollapseAll={onCollapseAll}
         />
       </Panel>
     </ReactFlow>

--- a/frontend/src/components/graph/DependencyGraph.tsx
+++ b/frontend/src/components/graph/DependencyGraph.tsx
@@ -63,7 +63,7 @@ function GraphInner({
 
   const handleNodeClick: NodeMouseHandler = useCallback(
     (_, node) => {
-      if (node.type === 'supercluster') {
+      if (node.type === 'supercluster' || node.type === 'cluster') {
         onToggleCluster(node.data.clusterKey as string)
       } else if (node.type === 'function' || node.type === 'file') {
         onSelectNode(node.id)

--- a/frontend/src/components/graph/GraphControls.tsx
+++ b/frontend/src/components/graph/GraphControls.tsx
@@ -6,9 +6,17 @@ type Props = {
   nodeKind: NodeKind
   onChangeNodeKind: (kind: NodeKind) => void
   onFitChanged: () => void
+  onExpandAll: () => void
+  onCollapseAll: () => void
 }
 
-export default function GraphControls({ nodeKind, onChangeNodeKind, onFitChanged }: Props) {
+export default function GraphControls({
+  nodeKind,
+  onChangeNodeKind,
+  onFitChanged,
+  onExpandAll,
+  onCollapseAll,
+}: Props) {
   return (
     <Card className="shadow-md border-stone-200 bg-white">
       <CardContent className="p-2 flex flex-col gap-2">
@@ -35,6 +43,19 @@ export default function GraphControls({ nodeKind, onChangeNodeKind, onFitChanged
           >
             ファイル
           </button>
+        </div>
+        <div className="flex gap-1">
+          <Button variant="outline" size="sm" className="h-7 flex-1 text-xs" onClick={onExpandAll}>
+            すべて展開
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 flex-1 text-xs"
+            onClick={onCollapseAll}
+          >
+            折りたたむ
+          </Button>
         </div>
         <Button variant="outline" size="sm" className="h-7 w-full text-xs" onClick={onFitChanged}>
           変更ノードに寄せる

--- a/frontend/src/components/graph/SuperClusterNode.tsx
+++ b/frontend/src/components/graph/SuperClusterNode.tsx
@@ -1,0 +1,36 @@
+import { Handle, Position, type NodeProps } from '@xyflow/react'
+import type { SuperClusterFlowNode } from '@/types/graph'
+
+export default function SuperClusterNode({ data }: NodeProps<SuperClusterFlowNode>) {
+  return (
+    <div
+      className={[
+        'relative rounded-xl border cursor-pointer transition-shadow hover:shadow-md',
+        'w-[240px]',
+        data.hasChanged ? 'ring-2 ring-amber-400' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      style={{
+        background: `color-mix(in srgb, ${data.clusterColorSoft} 50%, white)`,
+        borderColor: `color-mix(in srgb, ${data.clusterColorHex} 40%, transparent)`,
+        borderWidth: '1.5px',
+      }}
+    >
+      <div className="px-4 py-3">
+        <p className="truncate text-sm font-semibold" style={{ color: data.clusterColorHex }}>
+          {data.label}
+        </p>
+        <div className="mt-1 flex items-center gap-2 text-xs text-stone-400">
+          <span>{data.functionCount} 関数</span>
+          {data.changedCount > 0 && (
+            <span className="font-medium text-amber-500">{data.changedCount} 変更</span>
+          )}
+        </div>
+        <p className="mt-1.5 text-[10px] text-stone-300">クリックで展開</p>
+      </div>
+      <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
+      <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />
+    </div>
+  )
+}

--- a/frontend/src/lib/graphLayout.ts
+++ b/frontend/src/lib/graphLayout.ts
@@ -192,7 +192,7 @@ export function layoutGraph(
           } as ClusterGroupData,
           style: { width: clusterW, height: clusterH },
           draggable: false,
-          selectable: false,
+          selectable: true,
           zIndex: 0,
         })
 

--- a/frontend/src/lib/graphLayout.ts
+++ b/frontend/src/lib/graphLayout.ts
@@ -7,6 +7,7 @@ import type {
   FunctionNodeData,
   FileNodeData,
   ClusterGroupData,
+  SuperClusterNodeData,
 } from '@/types/graph'
 import { getClusterColor } from './clusterColors'
 import { inferLayer } from './layerInference'
@@ -24,6 +25,9 @@ const CLUSTER_LABEL_H = 28
 const CLUSTER_GAP = 48
 const LAYER_GAP = 64
 
+const SUPER_W = 240
+const SUPER_H = 90
+
 type InputNode = {
   id: string
   name: string
@@ -37,7 +41,16 @@ type InputNode = {
 
 export type LayoutResult = { nodes: AnyFlowNode[]; edges: Edge[] }
 
-export function layoutGraph(data: GraphResponse, nodeKind: NodeKind): LayoutResult {
+/** "layer:clusterId" 形式のキーを返す */
+export function makeClusterKey(pkg: string, clusterId: number): string {
+  return `${inferLayer(pkg)}:${clusterId}`
+}
+
+export function layoutGraph(
+  data: GraphResponse,
+  nodeKind: NodeKind,
+  expandedClusters: Set<string>,
+): LayoutResult {
   let inputNodes: InputNode[]
   let inputEdges: GraphEdge[]
   let clusters: Cluster[]
@@ -62,6 +75,10 @@ export function layoutGraph(data: GraphResponse, nodeKind: NodeKind): LayoutResu
     for (const nid of c.nodes) nodeToCluster.set(nid, c.id)
   }
 
+  // Build a quick lookup for nodes
+  const nodeMap = new Map<string, InputNode>()
+  for (const n of inputNodes) nodeMap.set(n.id, n)
+
   // Group nodes by (layer, clusterId)
   const groups = new Map<string, InputNode[]>()
   for (const n of inputNodes) {
@@ -73,12 +90,37 @@ export function layoutGraph(data: GraphResponse, nodeKind: NodeKind): LayoutResu
   }
 
   const flowNodes: AnyFlowNode[] = []
-  const flowEdges: Edge[] = inputEdges.map((e) => ({
-    id: `e:${e.from}->${e.to}`,
-    source: e.from,
-    target: e.to,
-    style: { stroke: '#d6d3d1', strokeWidth: 1.5 },
-  }))
+
+  // Build edges with cluster aggregation
+  const edgeSet = new Set<string>()
+  const flowEdges: Edge[] = []
+
+  for (const e of inputEdges) {
+    const fromNode = nodeMap.get(e.from)
+    const toNode = nodeMap.get(e.to)
+    if (!fromNode || !toNode) continue
+
+    const fromCid = nodeToCluster.get(e.from) ?? 0
+    const toCid = nodeToCluster.get(e.to) ?? 0
+    const fromKey = makeClusterKey(fromNode.package, fromCid)
+    const toKey = makeClusterKey(toNode.package, toCid)
+
+    const srcId = expandedClusters.has(fromKey) ? e.from : `super:${fromKey}`
+    const dstId = expandedClusters.has(toKey) ? e.to : `super:${toKey}`
+
+    if (srcId === dstId) continue
+
+    const edgeKey = `${srcId}→${dstId}`
+    if (edgeSet.has(edgeKey)) continue
+    edgeSet.add(edgeKey)
+
+    flowEdges.push({
+      id: `e:${edgeKey}`,
+      source: srcId,
+      target: dstId,
+      style: { stroke: '#d6d3d1', strokeWidth: 1.5 },
+    })
+  }
 
   let layerY = 0
 
@@ -100,81 +142,111 @@ export function layoutGraph(data: GraphResponse, nodeKind: NodeKind): LayoutResu
     for (const { cid, nodes } of layerGroups) {
       const color = getClusterColor(cid)
       const clusterLabel = clusters.find((c) => c.id === cid)?.label ?? `Cluster ${cid}`
+      const key = `${layer}:${cid}`
+      const isExpanded = expandedClusters.has(key)
 
-      const rows = Math.ceil(nodes.length / COLS)
-      const actualCols = Math.min(nodes.length, COLS)
-      const clusterW = PADDING * 2 + (actualCols - 1) * COL_STRIDE + NODE_W
-      const clusterH =
-        PADDING * 2 + CLUSTER_LABEL_H + rows * NODE_H + (rows - 1) * (ROW_STRIDE - NODE_H)
+      if (!isExpanded) {
+        // Collapsed: render a single super node
+        const changedCount = nodes.reduce((acc, n) => acc + n.changedCount, 0)
+        const functionCount = nodes.reduce((acc, n) => acc + n.functionCount, 0)
 
-      const clusterId = `cluster:${layer}:${cid}`
+        flowNodes.push({
+          id: `super:${key}`,
+          type: 'supercluster',
+          position: { x: clusterX, y: layerY },
+          data: {
+            label: clusterLabel,
+            clusterId: cid,
+            clusterKey: key,
+            clusterColorHex: color.hex,
+            clusterColorSoft: color.soft,
+            functionCount,
+            changedCount,
+            hasChanged: changedCount > 0,
+          } as SuperClusterNodeData,
+          style: { width: SUPER_W, height: SUPER_H },
+        })
 
-      flowNodes.push({
-        id: clusterId,
-        type: 'cluster',
-        position: { x: clusterX, y: layerY },
-        data: {
-          label: clusterLabel,
-          clusterId: cid,
-          clusterColorHex: color.hex,
-          clusterColorSoft: color.soft,
-        } as ClusterGroupData,
-        style: { width: clusterW, height: clusterH },
-        draggable: false,
-        selectable: false,
-        zIndex: 0,
-      })
+        clusterX += SUPER_W + CLUSTER_GAP
+        maxClusterH = Math.max(maxClusterH, SUPER_H)
+      } else {
+        // Expanded: render cluster container + child nodes
+        const rows = Math.ceil(nodes.length / COLS)
+        const actualCols = Math.min(nodes.length, COLS)
+        const clusterW = PADDING * 2 + (actualCols - 1) * COL_STRIDE + NODE_W
+        const clusterH =
+          PADDING * 2 + CLUSTER_LABEL_H + rows * NODE_H + (rows - 1) * (ROW_STRIDE - NODE_H)
 
-      nodes.forEach((n, i) => {
-        const col = i % COLS
-        const row = Math.floor(i / COLS)
-        const x = PADDING + col * COL_STRIDE
-        const y = PADDING + CLUSTER_LABEL_H + row * ROW_STRIDE
+        const clusterId = `cluster:${layer}:${cid}`
 
-        if (nodeKind === 'file') {
-          const fn = n as AggregatedFileNode
-          flowNodes.push({
-            id: n.id,
-            type: 'file',
-            parentId: clusterId,
-            extent: 'parent',
-            position: { x, y },
-            zIndex: 1,
-            data: {
-              fileName: fn.name,
-              packagePath: fn.package,
-              functionCount: fn.functionCount,
-              changedCount: fn.changedCount,
-              changed: fn.changed,
-              clusterId: cid,
-              clusterColorHex: color.hex,
-              layer,
-            } as FileNodeData,
-          })
-        } else {
-          flowNodes.push({
-            id: n.id,
-            type: 'function',
-            parentId: clusterId,
-            extent: 'parent',
-            position: { x, y },
-            zIndex: 1,
-            data: {
-              label: n.name,
-              packagePath: n.package,
-              file: n.file,
-              line: n.line,
-              changed: n.changed,
-              clusterId: cid,
-              clusterColorHex: color.hex,
-              layer,
-            } as FunctionNodeData,
-          })
-        }
-      })
+        flowNodes.push({
+          id: clusterId,
+          type: 'cluster',
+          position: { x: clusterX, y: layerY },
+          data: {
+            label: clusterLabel,
+            clusterId: cid,
+            clusterKey: key,
+            clusterColorHex: color.hex,
+            clusterColorSoft: color.soft,
+          } as ClusterGroupData,
+          style: { width: clusterW, height: clusterH },
+          draggable: false,
+          selectable: false,
+          zIndex: 0,
+        })
 
-      clusterX += clusterW + CLUSTER_GAP
-      maxClusterH = Math.max(maxClusterH, clusterH)
+        nodes.forEach((n, i) => {
+          const col = i % COLS
+          const row = Math.floor(i / COLS)
+          const x = PADDING + col * COL_STRIDE
+          const y = PADDING + CLUSTER_LABEL_H + row * ROW_STRIDE
+
+          if (nodeKind === 'file') {
+            const fn = n as AggregatedFileNode
+            flowNodes.push({
+              id: n.id,
+              type: 'file',
+              parentId: clusterId,
+              extent: 'parent',
+              position: { x, y },
+              zIndex: 1,
+              data: {
+                fileName: fn.name,
+                packagePath: fn.package,
+                functionCount: fn.functionCount,
+                changedCount: fn.changedCount,
+                changed: fn.changed,
+                clusterId: cid,
+                clusterColorHex: color.hex,
+                layer,
+              } as FileNodeData,
+            })
+          } else {
+            flowNodes.push({
+              id: n.id,
+              type: 'function',
+              parentId: clusterId,
+              extent: 'parent',
+              position: { x, y },
+              zIndex: 1,
+              data: {
+                label: n.name,
+                packagePath: n.package,
+                file: n.file,
+                line: n.line,
+                changed: n.changed,
+                clusterId: cid,
+                clusterColorHex: color.hex,
+                layer,
+              } as FunctionNodeData,
+            })
+          }
+        })
+
+        clusterX += clusterW + CLUSTER_GAP
+        maxClusterH = Math.max(maxClusterH, clusterH)
+      }
     }
 
     layerY += maxClusterH + LAYER_GAP

--- a/frontend/src/pages/AnalysisGraphView.tsx
+++ b/frontend/src/pages/AnalysisGraphView.tsx
@@ -6,6 +6,7 @@ import { useGraph } from '@/hooks/useGraph'
 import { useDiff } from '@/hooks/useDiff'
 import { inferLayer } from '@/lib/layerInference'
 import { getClusterColor } from '@/lib/clusterColors'
+import { makeClusterKey } from '@/lib/graphLayout'
 import AppShell from '@/components/layout/AppShell'
 import PRMetaBar from '@/components/layout/PRMetaBar'
 import DependencyGraph from '@/components/graph/DependencyGraph'
@@ -20,9 +21,65 @@ export default function AnalysisGraphView({ jobId }: Props) {
   const { data: diffData } = useDiff(jobId, !isLoading && !error && !!data)
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
   const [nodeKind, setNodeKind] = useState<NodeKind>('function')
+  // null = 未操作（自動展開ロジックを使う）、Set = ユーザー操作後の明示的な展開セット
+  const [expandedClustersOverride, setExpandedClustersOverride] = useState<Set<string> | null>(null)
 
   const handleChangeNodeKind = useCallback((kind: NodeKind) => {
     setNodeKind(kind)
+    setSelectedNodeId(null)
+  }, [])
+
+  // 変更関数を含むクラスタをデフォルト展開する（useEffect不要・レンダー時に計算）
+  const defaultExpandedClusters = useMemo(() => {
+    if (!data) return new Set<string>()
+    const expanded = new Set<string>()
+    for (const cluster of data.clusters) {
+      const hasChanged = cluster.nodes.some(
+        (nid) => data.graph.nodes.find((n) => n.id === nid)?.changed,
+      )
+      if (hasChanged) {
+        for (const nid of cluster.nodes) {
+          const n = data.graph.nodes.find((gn) => gn.id === nid)
+          if (n) expanded.add(makeClusterKey(n.package, cluster.id))
+        }
+      }
+    }
+    return expanded
+  }, [data])
+
+  const expandedClusters = expandedClustersOverride ?? defaultExpandedClusters
+
+  const allClusterKeys = useMemo(() => {
+    if (!data) return new Set<string>()
+    const keys = new Set<string>()
+    for (const cluster of data.clusters) {
+      for (const nid of cluster.nodes) {
+        const n = data.graph.nodes.find((gn) => gn.id === nid)
+        if (n) keys.add(makeClusterKey(n.package, cluster.id))
+      }
+    }
+    return keys
+  }, [data])
+
+  const handleToggleCluster = useCallback(
+    (key: string) => {
+      setExpandedClustersOverride((prev) => {
+        const base = prev !== null ? prev : defaultExpandedClusters
+        const next = new Set(base)
+        if (next.has(key)) next.delete(key)
+        else next.add(key)
+        return next
+      })
+    },
+    [defaultExpandedClusters],
+  )
+
+  const handleExpandAll = useCallback(() => {
+    setExpandedClustersOverride(new Set(allClusterKeys))
+  }, [allClusterKeys])
+
+  const handleCollapseAll = useCallback(() => {
+    setExpandedClustersOverride(new Set())
     setSelectedNodeId(null)
   }, [])
 
@@ -166,6 +223,10 @@ export default function AnalysisGraphView({ jobId }: Props) {
         onChangeNodeKind={handleChangeNodeKind}
         selectedNodeId={selectedNodeId}
         onSelectNode={setSelectedNodeId}
+        expandedClusters={expandedClusters}
+        onToggleCluster={handleToggleCluster}
+        onExpandAll={handleExpandAll}
+        onCollapseAll={handleCollapseAll}
       />
     </AppShell>
   )

--- a/frontend/src/pages/AnalysisGraphView.tsx
+++ b/frontend/src/pages/AnalysisGraphView.tsx
@@ -29,37 +29,33 @@ export default function AnalysisGraphView({ jobId }: Props) {
     setSelectedNodeId(null)
   }, [])
 
-  // 変更関数を含むクラスタをデフォルト展開する（useEffect不要・レンダー時に計算）
-  const defaultExpandedClusters = useMemo(() => {
-    if (!data) return new Set<string>()
-    const expanded = new Set<string>()
+  const { defaultExpandedClusters, allClusterKeys } = useMemo(() => {
+    const defaultExpanded = new Set<string>()
+    const allKeys = new Set<string>()
+    if (!data) return { defaultExpandedClusters: defaultExpanded, allClusterKeys: allKeys }
+
+    const nodeMap = new Map(data.graph.nodes.map((n) => [n.id, n]))
+
     for (const cluster of data.clusters) {
-      const hasChanged = cluster.nodes.some(
-        (nid) => data.graph.nodes.find((n) => n.id === nid)?.changed,
-      )
-      if (hasChanged) {
-        for (const nid of cluster.nodes) {
-          const n = data.graph.nodes.find((gn) => gn.id === nid)
-          if (n) expanded.add(makeClusterKey(n.package, cluster.id))
+      const clusterKeys = new Set<string>()
+      let hasChanged = false
+      for (const nid of cluster.nodes) {
+        const n = nodeMap.get(nid)
+        if (n) {
+          const key = makeClusterKey(n.package, cluster.id)
+          clusterKeys.add(key)
+          allKeys.add(key)
+          if (n.changed) hasChanged = true
         }
       }
+      if (hasChanged) {
+        clusterKeys.forEach((k) => defaultExpanded.add(k))
+      }
     }
-    return expanded
+    return { defaultExpandedClusters: defaultExpanded, allClusterKeys: allKeys }
   }, [data])
 
   const expandedClusters = expandedClustersOverride ?? defaultExpandedClusters
-
-  const allClusterKeys = useMemo(() => {
-    if (!data) return new Set<string>()
-    const keys = new Set<string>()
-    for (const cluster of data.clusters) {
-      for (const nid of cluster.nodes) {
-        const n = data.graph.nodes.find((gn) => gn.id === nid)
-        if (n) keys.add(makeClusterKey(n.package, cluster.id))
-      }
-    }
-    return keys
-  }, [data])
 
   const handleToggleCluster = useCallback(
     (key: string) => {

--- a/frontend/src/types/graph.ts
+++ b/frontend/src/types/graph.ts
@@ -30,13 +30,27 @@ export type FileNodeData = {
 export type ClusterGroupData = {
   label: string
   clusterId: number
+  clusterKey: string
   clusterColorHex: string
   clusterColorSoft: string
+  [key: string]: unknown
+}
+
+export type SuperClusterNodeData = {
+  label: string
+  clusterId: number
+  clusterKey: string
+  clusterColorHex: string
+  clusterColorSoft: string
+  functionCount: number
+  changedCount: number
+  hasChanged: boolean
   [key: string]: unknown
 }
 
 export type FunctionFlowNode = Node<FunctionNodeData, 'function'>
 export type FileFlowNode = Node<FileNodeData, 'file'>
 export type ClusterFlowNode = Node<ClusterGroupData, 'cluster'>
+export type SuperClusterFlowNode = Node<SuperClusterNodeData, 'supercluster'>
 
-export type AnyFlowNode = FunctionFlowNode | FileFlowNode | ClusterFlowNode
+export type AnyFlowNode = FunctionFlowNode | FileFlowNode | ClusterFlowNode | SuperClusterFlowNode


### PR DESCRIPTION
closes #54

## 変更概要

大規模 PR でノード数が多すぎてグラフが読めない問題を解消するため、クラスタ単位での折りたたみ／展開機能を実装した。

## 主な変更点

- **`SuperClusterNode` を新規追加**: 折りたたみ状態のクラスタを 1 つのスーパーノードとして表示。ラベル・関数数・変更数を表示し、変更ありの場合は amber リングで強調
- **`graphLayout.ts`**: `expandedClusters: Set<string>` を受け取り、折りたたまれたクラスタはスーパーノードを生成、クラスタ間エッジを集約（重複・自己ループ除去）
- **`DependencyGraph.tsx`**: `supercluster` / `cluster` ノードのクリックでトグル処理
- **`GraphControls.tsx`**: 「すべて展開 / 折りたたむ」ボタンを追加
- **`AnalysisGraphView.tsx`**: 変更関数を含むクラスタを初期展開（`useMemo + override` パターンで ESLint 準拠）

## 操作フロー

| 状態 | 操作 | 結果 |
|---|---|---|
| 折りたたみ中 (SuperClusterNode) | クリック | そのクラスタを展開 |
| 展開中 (ClusterGroup) | 背景 or ヘッダーの `−` をクリック | そのクラスタを折りたたむ |
| — | 「すべて展開」ボタン | 全クラスタ展開 |
| — | 「折りたたむ」ボタン | 全クラスタ折りたたみ |

ロード時は変更関数を含むクラスタのみ自動展開し、それ以外は折りたたみ状態で初期表示する。