### PR TITLE
refactor: クラスタラベル生成を infra から usecase へ移動 (#63)

### DIFF
--- a/.claude/rules/backend-architecture.md
+++ b/.claude/rules/backend-architecture.md
@@ -100,13 +100,8 @@ domain 型のみで動き外部 I/O を行わない関数（ラベリング・�
 |---|---|---|
 | `*sql.DB` を受け取る `AnalysisRepo.Save` | `infra/store/` | DB I/O あり |
 | `domain.Graph` を groupBy する `regroupBy` | `usecase/` | pure、usecase 内で完結 |
-| `domain.Node` 群から代表ラベルを生成する `labelCluster` | `usecase/` または `domain/` | pure、usecase の責務に近い |
+| `domain.Node` 群から代表ラベルを生成する `labelCluster` | `usecase/` | pure、usecase の責務に近い（`usecase/cluster_label.go`） |
 | GitHub API を呼ぶ `prRepo.GetPR` | `infra/github/` | 外部 API |
-
-### 既存コードへの注意
-
-`infra/cluster/labeler.go` は本ルール導入前のコードで、pure logic が `infra/` に置かれている。
-別 issue で `usecase/` または `domain/` へ移動予定。新規追加では真似しないこと。
 
 ---
 

--- a/backend/internal/infra/cluster/louvain.go
+++ b/backend/internal/infra/cluster/louvain.go
@@ -33,6 +33,9 @@ func NewLouvainClusterer() *LouvainClusterer {
 
 // Cluster は domain.Graph を Louvain 法でクラスタリングし domain.ClusterResult を返す。
 // g が nil またはノードを持たない場合は空の ClusterResult を返す。
+//
+// 返却される Cluster の Label は空のままにする。表示用ラベルは usecase 層が読み出し時に付与する
+// （Package/File モードと対称にするため。`.claude/rules/backend-architecture.md` §4 参照）。
 func (c *LouvainClusterer) Cluster(ctx context.Context, g *domain.Graph) (*domain.ClusterResult, error) {
 	if g == nil || len(g.Nodes) == 0 {
 		return &domain.ClusterResult{}, nil
@@ -53,12 +56,6 @@ func (c *LouvainClusterer) Cluster(ctx context.Context, g *domain.Graph) (*domai
 	reduced := community.Modularize(adapter.g, resolution, src)
 	communities := reduced.Communities()
 
-	// ノードの集合を domain.NodeID スライスに変換し、各クラスタのノードを収集する
-	nodeByID := make(map[domain.NodeID]domain.Node, len(g.Nodes))
-	for _, n := range g.Nodes {
-		nodeByID[n.ID] = n
-	}
-
 	// サイズ降順でソートして安定した ID を付与する
 	sort.Slice(communities, func(i, j int) bool {
 		return len(communities[i]) > len(communities[j])
@@ -71,22 +68,16 @@ func (c *LouvainClusterer) Cluster(ctx context.Context, g *domain.Graph) (*domai
 		}
 
 		nodeIDs := make([]domain.NodeID, 0, len(comm))
-		clusterNodes := make([]domain.Node, 0, len(comm))
 		for _, gNode := range comm {
 			domainID, ok := adapter.idToNode[gNode.ID()]
 			if !ok {
 				continue
 			}
 			nodeIDs = append(nodeIDs, domainID)
-			if n, exists := nodeByID[domainID]; exists {
-				clusterNodes = append(clusterNodes, n)
-			}
 		}
 
-		label := labelCluster(i, clusterNodes, g.Edges)
 		clusters = append(clusters, domain.Cluster{
 			ID:    i,
-			Label: label,
 			Nodes: nodeIDs,
 		})
 	}

--- a/backend/internal/usecase/cluster_label.go
+++ b/backend/internal/usecase/cluster_label.go
@@ -1,4 +1,4 @@
-package cluster
+package usecase
 
 import (
 	"fmt"
@@ -8,6 +8,31 @@ import (
 
 	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
 )
+
+// labelClusters は clusters の各クラスタに対し graph の情報からラベルを計算し、
+// Label を差し替えた新しいスライスを返す。入力の clusters は変更しない。
+func labelClusters(clusters []domain.Cluster, g domain.Graph) []domain.Cluster {
+	if len(clusters) == 0 {
+		return clusters
+	}
+	nodeByID := make(map[domain.NodeID]domain.Node, len(g.Nodes))
+	for _, n := range g.Nodes {
+		nodeByID[n.ID] = n
+	}
+	out := make([]domain.Cluster, len(clusters))
+	for i, c := range clusters {
+		clusterNodes := make([]domain.Node, 0, len(c.Nodes))
+		for _, id := range c.Nodes {
+			if n, ok := nodeByID[id]; ok {
+				clusterNodes = append(clusterNodes, n)
+			}
+		}
+		labeled := c
+		labeled.Label = labelCluster(c.ID, clusterNodes, g.Edges)
+		out[i] = labeled
+	}
+	return out
+}
 
 // labelCluster はクラスタを構成するノード群から人間に読めるラベルを生成する。
 //

--- a/backend/internal/usecase/cluster_label.go
+++ b/backend/internal/usecase/cluster_label.go
@@ -19,6 +19,9 @@ func labelClusters(clusters []domain.Cluster, g domain.Graph) []domain.Cluster {
 	for _, n := range g.Nodes {
 		nodeByID[n.ID] = n
 	}
+	// 入次数はグラフ全体で一度だけ計算し、全クラスタで使い回す（O(E)）。
+	// クラスタ毎に再計算すると O(C×E) になるため。
+	inDeg := computeInDegree(g.Edges)
 	out := make([]domain.Cluster, len(clusters))
 	for i, c := range clusters {
 		clusterNodes := make([]domain.Node, 0, len(c.Nodes))
@@ -28,7 +31,7 @@ func labelClusters(clusters []domain.Cluster, g domain.Graph) []domain.Cluster {
 			}
 		}
 		labeled := c
-		labeled.Label = labelCluster(c.ID, clusterNodes, g.Edges)
+		labeled.Label = labelCluster(c.ID, clusterNodes, inDeg)
 		out[i] = labeled
 	}
 	return out
@@ -45,12 +48,12 @@ func labelClusters(clusters []domain.Cluster, g domain.Graph) []domain.Cluster {
 //  4. tie-break は名前の昇順
 //
 // パッケージ名・関数名のいずれも欠けている場合は "cluster N" にフォールバックする。
-func labelCluster(idx int, nodes []domain.Node, edges []domain.Edge) string {
+func labelCluster(idx int, nodes []domain.Node, inDeg map[domain.NodeID]int) string {
 	if len(nodes) == 0 {
 		return fmt.Sprintf("cluster %d", idx)
 	}
 
-	rep := pickRepresentative(nodes, edges)
+	rep := pickRepresentative(nodes, inDeg)
 	short := shortPackage(rep.Package)
 
 	switch {
@@ -66,9 +69,8 @@ func labelCluster(idx int, nodes []domain.Node, edges []domain.Edge) string {
 }
 
 // pickRepresentative はクラスタから代表ノードを選ぶ。len(nodes) > 0 を前提とする。
-func pickRepresentative(nodes []domain.Node, edges []domain.Edge) domain.Node {
-	inDeg := computeInDegree(nodes, edges)
-
+// inDeg はグラフ全体の入次数マップ（computeInDegree の結果）を想定する。
+func pickRepresentative(nodes []domain.Node, inDeg map[domain.NodeID]int) domain.Node {
 	candidates := filterNodes(nodes, func(n domain.Node) bool { return n.Changed })
 	if len(candidates) == 0 {
 		candidates = nodes
@@ -88,18 +90,12 @@ func pickRepresentative(nodes []domain.Node, edges []domain.Edge) domain.Node {
 	return best
 }
 
-// computeInDegree はクラスタ内ノードに対するグラフ全体での入次数を返す。
+// computeInDegree はグラフ全体の各ノードの入次数を返す。
 // edges は cluster を跨ぐ呼び出しも含むグラフ全体のエッジを想定する。
-func computeInDegree(nodes []domain.Node, edges []domain.Edge) map[domain.NodeID]int {
-	set := make(map[domain.NodeID]struct{}, len(nodes))
-	for _, n := range nodes {
-		set[n.ID] = struct{}{}
-	}
-	deg := make(map[domain.NodeID]int, len(nodes))
+func computeInDegree(edges []domain.Edge) map[domain.NodeID]int {
+	deg := make(map[domain.NodeID]int, len(edges))
 	for _, e := range edges {
-		if _, ok := set[e.To]; ok {
-			deg[e.To]++
-		}
+		deg[e.To]++
 	}
 	return deg
 }

--- a/backend/internal/usecase/cluster_label_test.go
+++ b/backend/internal/usecase/cluster_label_test.go
@@ -35,7 +35,7 @@ func TestLabelCluster_PrefersChangedOverHigherInDegree(t *testing.T) {
 		{From: "a", To: "b"},
 		{From: "ext", To: "b"},
 	}
-	got := labelCluster(0, nodes, edges)
+	got := labelCluster(0, nodes, computeInDegree(edges))
 	want := "pkg.Important"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -51,7 +51,7 @@ func TestLabelCluster_PrefersExportedAmongChanged(t *testing.T) {
 	edges := []domain.Edge{
 		{From: "x", To: "b"}, // private の方が in-degree 高いが exported 優先
 	}
-	got := labelCluster(0, nodes, edges)
+	got := labelCluster(0, nodes, computeInDegree(edges))
 	want := "pkg.Public"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -70,7 +70,7 @@ func TestLabelCluster_PicksHighestInDegree(t *testing.T) {
 		{From: "b", To: "c"},
 		{From: "a", To: "b"},
 	}
-	got := labelCluster(0, nodes, edges)
+	got := labelCluster(0, nodes, computeInDegree(edges))
 	want := "pkg.CCC"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -100,7 +100,7 @@ func TestLabelCluster_AllUnchangedFallsThrough(t *testing.T) {
 	edges := []domain.Edge{
 		{From: "x", To: "a"}, // a の in-degree が高い
 	}
-	got := labelCluster(0, nodes, edges)
+	got := labelCluster(0, nodes, computeInDegree(edges))
 	want := "pkg.Foo"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)

--- a/backend/internal/usecase/cluster_label_test.go
+++ b/backend/internal/usecase/cluster_label_test.go
@@ -1,4 +1,4 @@
-package cluster
+package usecase
 
 import (
 	"testing"
@@ -141,5 +141,55 @@ func TestLabelCluster_NoPackageNoName(t *testing.T) {
 	want := "cluster 3"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestLabelClusters_AppliesLabelsFromGraph(t *testing.T) {
+	// labelClusters はクラスタの NodeIDs とグラフのノード情報を組み合わせてラベルを付ける。
+	g := domain.Graph{
+		Nodes: []domain.Node{
+			{ID: "fn:A", Name: "Alpha", Package: "pkg/a", Changed: true},
+			{ID: "fn:B", Name: "Beta", Package: "pkg/b"},
+		},
+	}
+	in := []domain.Cluster{
+		{ID: 0, Nodes: []domain.NodeID{"fn:A"}},
+		{ID: 1, Nodes: []domain.NodeID{"fn:B"}},
+	}
+	got := labelClusters(in, g)
+
+	if len(got) != 2 {
+		t.Fatalf("len: got %d, want 2", len(got))
+	}
+	if got[0].Label != "a.Alpha" {
+		t.Errorf("clusters[0].Label: got %q, want %q", got[0].Label, "a.Alpha")
+	}
+	if got[1].Label != "b.Beta" {
+		t.Errorf("clusters[1].Label: got %q, want %q", got[1].Label, "b.Beta")
+	}
+	// 入力は変更されない
+	if in[0].Label != "" || in[1].Label != "" {
+		t.Errorf("input mutated: %+v", in)
+	}
+}
+
+func TestLabelClusters_EmptyInputReturnedAsIs(t *testing.T) {
+	if got := labelClusters(nil, domain.Graph{}); got != nil {
+		t.Errorf("nil input: got %+v, want nil", got)
+	}
+	empty := []domain.Cluster{}
+	got := labelClusters(empty, domain.Graph{})
+	if len(got) != 0 {
+		t.Errorf("empty input: got %d clusters, want 0", len(got))
+	}
+}
+
+func TestLabelClusters_MissingNodeIDFallsBackToClusterID(t *testing.T) {
+	// グラフに存在しない NodeID しか持たないクラスタ → "cluster N" にフォールバック
+	g := domain.Graph{Nodes: []domain.Node{{ID: "fn:X"}}}
+	in := []domain.Cluster{{ID: 5, Nodes: []domain.NodeID{"fn:missing"}}}
+	got := labelClusters(in, g)
+	if got[0].Label != "cluster 5" {
+		t.Errorf("got %q, want %q", got[0].Label, "cluster 5")
 	}
 }

--- a/backend/internal/usecase/get_analysis_test.go
+++ b/backend/internal/usecase/get_analysis_test.go
@@ -120,13 +120,17 @@ func TestGetGraph_Success(t *testing.T) {
 
 // GetGraph はリポジトリから取得した Analysis を直接書き換えてはならない。
 // （将来リポジトリがキャッシュ化された際に副作用が漏れないようにするための回帰テスト）
+//
+// 補足: 現在はクラスタラベルを usecase 層が読み出し時に付与するため、
+// Louvain モードでも返却される Cluster.Label は計算結果になる。
+// リポジトリに保存された側はラベル無しのまま変化しないことを検証する。
 func TestGetGraph_DoesNotMutateRepoAnalysis(t *testing.T) {
 	original := &domain.ClusterResult{
-		Clusters: []domain.Cluster{{ID: 0, Label: "louvain-0", Nodes: []domain.NodeID{"fn:A"}}},
+		Clusters: []domain.Cluster{{ID: 0, Nodes: []domain.NodeID{"fn:A"}}},
 		Graph: domain.Graph{
 			Nodes: []domain.Node{
-				{ID: "fn:A", Package: "pkg/a", File: "a.go"},
-				{ID: "fn:B", Package: "pkg/b", File: "b.go"},
+				{ID: "fn:A", Name: "Alpha", Package: "pkg/a", File: "a.go"},
+				{ID: "fn:B", Name: "Beta", Package: "pkg/b", File: "b.go"},
 			},
 		},
 	}
@@ -148,17 +152,21 @@ func TestGetGraph_DoesNotMutateRepoAnalysis(t *testing.T) {
 	if stored.Result != original {
 		t.Fatalf("repo analysis.Result was replaced; want same pointer as original")
 	}
-	if len(stored.Result.Clusters) != 1 || stored.Result.Clusters[0].Label != "louvain-0" {
+	if len(stored.Result.Clusters) != 1 || stored.Result.Clusters[0].Label != "" {
 		t.Errorf("original clusters mutated: %+v", stored.Result.Clusters)
 	}
 
-	// 続けて louvain で取得したら元の結果が返ること
+	// 続けて louvain で取得したら、ラベルが付与された Louvain 結果が返ること
+	// （ノード集合は元の Clusters と同じ、Label のみ計算済み）。
 	got, err := uc.GetGraph(context.Background(), "j1", domain.ClusterModeLouvain)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(got.Result.Clusters) != 1 || got.Result.Clusters[0].Label != "louvain-0" {
-		t.Errorf("louvain result was contaminated by previous package call: %+v", got.Result.Clusters)
+	if len(got.Result.Clusters) != 1 {
+		t.Fatalf("louvain result was contaminated by previous package call: %+v", got.Result.Clusters)
+	}
+	if got.Result.Clusters[0].Label != "a.Alpha" {
+		t.Errorf("louvain label: got %q, want %q", got.Result.Clusters[0].Label, "a.Alpha")
 	}
 }
 

--- a/backend/internal/usecase/regroup.go
+++ b/backend/internal/usecase/regroup.go
@@ -8,16 +8,29 @@ import (
 )
 
 // applyClusterMode は ClusterMode に応じて ClusterResult のクラスタ分割を上書きして返す。
-// mode が ClusterModeLouvain または result が nil の場合はそのまま返す。
-// Package/File モードは result.Graph のノードを各キーで groupBy する。
+// result が nil の場合はそのまま返す。
+//   - Louvain: 保存済みクラスタ分割を保ち、ラベルだけ labelClusters で付け直す
+//     （Cluster() は Label 空のクラスタを返す契約）。
+//   - Package/File: result.Graph のノードを各キーで groupBy しラベルも付与する。
 func applyClusterMode(result *domain.ClusterResult, mode domain.ClusterMode) *domain.ClusterResult {
-	if result == nil || mode == domain.ClusterModeLouvain {
+	if result == nil {
 		return result
 	}
-	return &domain.ClusterResult{
-		Clusters: regroupBy(result.Graph, mode),
-		Graph:    result.Graph,
-		Cycles:   result.Cycles,
+	switch mode {
+	case domain.ClusterModeLouvain:
+		return &domain.ClusterResult{
+			Clusters: labelClusters(result.Clusters, result.Graph),
+			Graph:    result.Graph,
+			Cycles:   result.Cycles,
+		}
+	case domain.ClusterModePackage, domain.ClusterModeFile:
+		return &domain.ClusterResult{
+			Clusters: regroupBy(result.Graph, mode),
+			Graph:    result.Graph,
+			Cycles:   result.Cycles,
+		}
+	default:
+		return result
 	}
 }
 


### PR DESCRIPTION
Closes #63

## Summary
- `infra/cluster/labeler.go` を `usecase/cluster_label.go` に移動（backend-architecture.md §4 「純粋な変換ヘルパーの配置」ルール準拠）
- `LouvainClusterer.Cluster` は Label 空のクラスタを返す契約に変更し、ラベル付与は usecase 層が読み出し時に行うよう統一（Package/File モードと対称）
- `applyClusterMode` を switch 文に書き換え、Louvain モードでも `labelClusters` ヘルパでラベルを後付け
- backend-architecture.md §4 から「既存コードへの注意」段落（labeler.go についての TODO）を削除

## Test plan
- [x] `gofmt -w . && go vet ./...` 通過（Docker 経由）
- [x] `go test ./...` 全パッケージ green（Docker 経由）
- [x] 新規ヘルパ `labelClusters` の単体テスト追加（空入力／NodeID 欠落のフォールバック含む）
- [x] `TestGetGraph_DoesNotMutateRepoAnalysis` を新契約（Louvain も読み出し時ラベリング）に合わせて更新
- [ ] **UI 実機確認（ユーザー側で要確認）**: グラフ表示で Louvain / Package / File いずれのモードでもクラスタラベルが従来通り表示されること

## 関連
- #61（ルール追加）
- #52（議論の発端）