### PR TITLE
feat: 解析中の進捗ステップをジョブの実フェーズと連動させる

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,10 @@
      - 確認対象: 変更画面の golden path + 関連画面のリグレッション
      - lint / 型チェック / テストが通っても「機能として正しく動く」ことの保証にはならないため必須
      - AI エージェントは CLI 環境では実機確認できないので、PR の Test plan にチェック項目として明示し、ユーザー側で確認してもらう
+   - **バックエンドのコードを変更したら dev server に反映するため再ビルドが必要**
+     - `backend` コンテナはソースを bind mount せず `compose.yml` の `build:` でイメージに焼き込むため、`docker compose up` だけでは古いバイナリのまま動く（フロントは bind mount なので即反映され、挙動が食い違う）
+     - 反映コマンド: `docker compose up -d --build backend`（または `docker compose watch`）
+     - `docker compose run --rm backend ...`（lint / test）は実行ごとにビルドされるのでこの影響は受けない
 5. コミット（[`.claude/rules/commit-style.md`](./.claude/rules/commit-style.md) に従う）
 6. push して PR を作成（`develop` 宛）
 7. ユーザーにレビュー依頼

--- a/backend/internal/api/dto.go
+++ b/backend/internal/api/dto.go
@@ -11,6 +11,7 @@ type AnalyzeRequest struct {
 type JobResponse struct {
 	JobID      string `json:"job_id"`
 	Status     string `json:"status"`
+	Phase      string `json:"phase,omitempty"`
 	AnalysisID string `json:"analysis_id,omitempty"`
 	Error      string `json:"error,omitempty"`
 }

--- a/backend/internal/api/job_handler.go
+++ b/backend/internal/api/job_handler.go
@@ -37,6 +37,7 @@ func (h *JobHandler) Get(c echo.Context) error {
 	return c.JSON(http.StatusOK, JobResponse{
 		JobID:      string(j.ID),
 		Status:     string(j.Status),
+		Phase:      string(j.Phase),
 		AnalysisID: string(j.AnalysisID),
 		Error:      j.Error,
 	})

--- a/backend/internal/domain/job.go
+++ b/backend/internal/domain/job.go
@@ -15,12 +15,25 @@ const (
 	JobStatusError   JobStatus = "error"
 )
 
+// JobPhase は running 中のジョブの現在フェーズ。フロントの進捗ステップ表示に使う。
+// pending のあいだは空文字、done/error 後は値を参照しない。
+type JobPhase string
+
+const (
+	JobPhaseClone      JobPhase = "clone"       // リポジトリのクローン
+	JobPhaseBuildGraph JobPhase = "build_graph" // 依存グラフの構築 (AST 解析)
+	JobPhaseDiff       JobPhase = "diff"        // 差分との突き合わせ
+	JobPhaseCluster    JobPhase = "cluster"     // クラスタ分類
+	JobPhaseVisualize  JobPhase = "visualize"   // 可視化の生成
+)
+
 // Job は非同期解析ジョブのエンティティ
 type Job struct {
 	ID         JobID
 	AnalysisID AnalysisID
 	PR         PRInfo
 	Status     JobStatus
+	Phase      JobPhase
 	Error      string
 	CreatedAt  time.Time
 	UpdatedAt  time.Time

--- a/backend/internal/infra/job/worker.go
+++ b/backend/internal/infra/job/worker.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
+	"sync"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -19,6 +20,7 @@ import (
 type jobStore interface {
 	FindByID(ctx context.Context, id domain.JobID) (*domain.Job, error)
 	UpdateStatus(ctx context.Context, id domain.JobID, status domain.JobStatus, errMsg string) error
+	UpdatePhase(ctx context.Context, id domain.JobID, phase domain.JobPhase) error
 	UpdateAnalysisID(ctx context.Context, id domain.JobID, analysisID domain.AnalysisID) error
 }
 
@@ -85,10 +87,18 @@ func (w *Worker) process(ctx context.Context, item Item) {
 		log.Printf("worker: job %s failed: %v", jobID, err)
 		_ = w.jobs.UpdateStatus(ctx, jobID, domain.JobStatusError, err.Error())
 	}
+	// setPhase はフロントの進捗表示用にジョブの現在フェーズを更新する。
+	// 進捗表示は付随情報なので、失敗してもジョブ自体は止めずログのみ残す。
+	setPhase := func(p domain.JobPhase) {
+		if err := w.jobs.UpdatePhase(ctx, jobID, p); err != nil {
+			log.Printf("worker: failed to set phase %s for job %s: %v", p, jobID, err)
+		}
+	}
 
 	if err := w.jobs.UpdateStatus(ctx, jobID, domain.JobStatusRunning, ""); err != nil {
 		log.Printf("worker: failed to mark job %s running: %v", jobID, err)
 	}
+	setPhase(domain.JobPhaseClone)
 
 	j, err := w.jobs.FindByID(ctx, jobID)
 	if err != nil {
@@ -116,8 +126,13 @@ func (w *Worker) process(ctx context.Context, item Item) {
 	}
 	log.Printf("worker: ListChangedGoFiles took %s (%d files)", time.Since(t0), len(changed))
 
+	// クローン完了後、最初にグラフ構築へ入った時点で一度だけ build_graph フェーズへ移す
+	// (base/head が並列なため sync.Once で先着のみ反映する)。
+	var buildOnce sync.Once
+	onBuild := func() { buildOnce.Do(func() { setPhase(domain.JobPhaseBuildGraph) }) }
+
 	t1 := time.Now()
-	headGraph, baseGraph, cleanups, err := w.buildBothGraphs(ctx, *prInfo, item.Token, changed)
+	headGraph, baseGraph, cleanups, err := w.buildBothGraphs(ctx, *prInfo, item.Token, changed, onBuild)
 	defer func() {
 		for _, c := range cleanups {
 			if c != nil {
@@ -134,12 +149,14 @@ func (w *Worker) process(ctx context.Context, item Item) {
 		len(headGraph.Nodes), len(headGraph.Edges),
 		len(baseGraph.Nodes), len(baseGraph.Edges))
 
+	setPhase(domain.JobPhaseDiff)
 	// base/head のグラフを合成して DiffStatus を付与する
 	diffGraph := analyzer.MergeWithDiffStatus(baseGraph, headGraph)
 
 	// 循環参照を検出（base にあった cycle と比較して IsNew を決定）
 	cycles := analyzer.DetectNewCycles(baseGraph, headGraph)
 
+	setPhase(domain.JobPhaseCluster)
 	t3 := time.Now()
 	result, err := w.clusterer.Cluster(ctx, diffGraph)
 	if err != nil {
@@ -149,6 +166,7 @@ func (w *Worker) process(ctx context.Context, item Item) {
 	result.Cycles = cycles
 	log.Printf("worker: Cluster took %s (cycles=%d)", time.Since(t3), len(cycles))
 
+	setPhase(domain.JobPhaseVisualize)
 	t4 := time.Now()
 	diffFiles, err := analyzer.CollectDiffFiles(ctx, w.prRepo, item.Token, *prInfo, changed)
 	if err != nil {
@@ -183,11 +201,13 @@ func (w *Worker) process(ctx context.Context, item Item) {
 // buildBothGraphs は head/base 両方の callgraph を errgroup で並列に構築する。
 // 戻り値の cleanups スライスには各 PreparedSource.Cleanup が入る（呼び出し元が defer で全部呼ぶこと）。
 // 一方が失敗した時点で他方の ctx もキャンセルされ、エラーが返る。
+// onBuild は各 Prepare（クローン）完了後・Build 開始前に呼ばれる進捗通知コールバック。
 func (w *Worker) buildBothGraphs(
 	ctx context.Context,
 	pr domain.PRInfo,
 	token string,
 	changed []domain.ChangedFile,
+	onBuild func(),
 ) (head, base *domain.Graph, cleanups []func() error, err error) {
 	cleanups = make([]func() error, 2)
 
@@ -199,6 +219,7 @@ func (w *Worker) buildBothGraphs(
 			return fmt.Errorf("head prepare: %w", err)
 		}
 		cleanups[0] = prepared.Cleanup
+		onBuild()
 		g, err := w.cgBuilder.Build(egCtx, prepared.Packages, prepared.ChangedPackages, prepared.ChangedFileAbsPaths, prepared.RepoRoot)
 		if err != nil {
 			return fmt.Errorf("head build: %w", err)
@@ -214,6 +235,7 @@ func (w *Worker) buildBothGraphs(
 			return fmt.Errorf("base prepare: %w", err)
 		}
 		cleanups[1] = prepared.Cleanup
+		onBuild()
 		g, err := w.cgBuilder.Build(egCtx, prepared.Packages, prepared.ChangedPackages, prepared.ChangedFileAbsPaths, prepared.RepoRoot)
 		if err != nil {
 			return fmt.Errorf("base build: %w", err)

--- a/backend/internal/infra/job/worker_test.go
+++ b/backend/internal/infra/job/worker_test.go
@@ -25,7 +25,8 @@ type fakeJobStore struct {
 		id         domain.JobID
 		analysisID domain.AnalysisID
 	}
-	findErr error
+	phaseCalls []domain.JobPhase
+	findErr    error
 }
 
 func newFakeJobStore() *fakeJobStore {
@@ -47,6 +48,14 @@ func (s *fakeJobStore) UpdateStatus(_ context.Context, id domain.JobID, status d
 	}{id, status, errMsg})
 	if j, ok := s.jobs[id]; ok {
 		j.Status = status
+	}
+	return nil
+}
+
+func (s *fakeJobStore) UpdatePhase(_ context.Context, id domain.JobID, phase domain.JobPhase) error {
+	s.phaseCalls = append(s.phaseCalls, phase)
+	if j, ok := s.jobs[id]; ok {
+		j.Phase = phase
 	}
 	return nil
 }
@@ -208,6 +217,22 @@ func TestWorker_HappyPath(t *testing.T) {
 	}
 	if analyses.saved[0].ID != fixedID {
 		t.Errorf("unexpected analysis ID: %s", analyses.saved[0].ID)
+	}
+	// フェーズが順番どおりに記録されたことを確認（build_graph は sync.Once で 1 回のみ）
+	wantPhases := []domain.JobPhase{
+		domain.JobPhaseClone,
+		domain.JobPhaseBuildGraph,
+		domain.JobPhaseDiff,
+		domain.JobPhaseCluster,
+		domain.JobPhaseVisualize,
+	}
+	if len(jobs.phaseCalls) != len(wantPhases) {
+		t.Fatalf("phase calls: got %v want %v", jobs.phaseCalls, wantPhases)
+	}
+	for i, p := range wantPhases {
+		if jobs.phaseCalls[i] != p {
+			t.Errorf("phase[%d]: got %s want %s", i, jobs.phaseCalls[i], p)
+		}
 	}
 	// base/head が両方呼ばれたことを確認
 	if st.prepareCalls != 1 {

--- a/backend/internal/infra/store/db.go
+++ b/backend/internal/infra/store/db.go
@@ -38,6 +38,9 @@ func migrate(db *sql.DB) error {
 	if err := addColumnIfNotExists(db, "jobs", "pr_base_sha", "TEXT NOT NULL DEFAULT ''"); err != nil {
 		return err
 	}
+	if err := addColumnIfNotExists(db, "jobs", "phase", "TEXT NOT NULL DEFAULT ''"); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/backend/internal/infra/store/job_repo.go
+++ b/backend/internal/infra/store/job_repo.go
@@ -27,10 +27,10 @@ func (r *JobRepo) Save(ctx context.Context, j *domain.Job) error {
 		analysisID = sql.NullString{String: string(j.AnalysisID), Valid: true}
 	}
 	_, err := r.db.ExecContext(ctx,
-		`INSERT INTO jobs (id, analysis_id, status, error, created_at, updated_at,
+		`INSERT INTO jobs (id, analysis_id, status, phase, error, created_at, updated_at,
 		 pr_owner, pr_repo, pr_number, pr_title, pr_base_ref, pr_head_ref, pr_head_sha, pr_base_sha)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		string(j.ID), analysisID, string(j.Status), j.Error,
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		string(j.ID), analysisID, string(j.Status), string(j.Phase), j.Error,
 		j.CreatedAt.UTC(), j.UpdatedAt.UTC(),
 		j.PR.Owner, j.PR.Repo, j.PR.Number,
 		j.PR.Title, j.PR.BaseRef, j.PR.HeadRef, j.PR.HeadSHA, j.PR.BaseSHA,
@@ -49,6 +49,19 @@ func (r *JobRepo) UpdateStatus(ctx context.Context, id domain.JobID, status doma
 	)
 	if err != nil {
 		return fmt.Errorf("update job status: %w", err)
+	}
+	return nil
+}
+
+// UpdatePhase は running 中のジョブの現在フェーズを更新する。ワーカー専用。
+// このメソッドは domain.JobRepository インターフェースには含まれない。
+func (r *JobRepo) UpdatePhase(ctx context.Context, id domain.JobID, phase domain.JobPhase) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE jobs SET phase=?, updated_at=? WHERE id=?`,
+		string(phase), time.Now().UTC(), string(id),
+	)
+	if err != nil {
+		return fmt.Errorf("update job phase: %w", err)
 	}
 	return nil
 }
@@ -86,6 +99,7 @@ func (r *JobRepo) FindByID(ctx context.Context, id domain.JobID) (*domain.Job, e
 	var (
 		analysisID sql.NullString
 		status     string
+		phase      string
 		errMsg     sql.NullString
 		createdAt  time.Time
 		updatedAt  time.Time
@@ -99,12 +113,12 @@ func (r *JobRepo) FindByID(ctx context.Context, id domain.JobID) (*domain.Job, e
 		prBaseSHA  string
 	)
 	err := r.db.QueryRowContext(ctx,
-		`SELECT analysis_id, status, error, created_at, updated_at,
+		`SELECT analysis_id, status, phase, error, created_at, updated_at,
 		 pr_owner, pr_repo, pr_number, pr_title, pr_base_ref, pr_head_ref, pr_head_sha, pr_base_sha
 		 FROM jobs WHERE id = ?`,
 		string(id),
 	).Scan(
-		&analysisID, &status, &errMsg, &createdAt, &updatedAt,
+		&analysisID, &status, &phase, &errMsg, &createdAt, &updatedAt,
 		&prOwner, &prRepo, &prNumber, &prTitle, &prBaseRef, &prHeadRef, &prHeadSHA, &prBaseSHA,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -117,6 +131,7 @@ func (r *JobRepo) FindByID(ctx context.Context, id domain.JobID) (*domain.Job, e
 	j := &domain.Job{
 		ID:        id,
 		Status:    domain.JobStatus(status),
+		Phase:     domain.JobPhase(phase),
 		CreatedAt: createdAt,
 		UpdatedAt: updatedAt,
 		PR: domain.PRInfo{

--- a/backend/internal/infra/store/schema.sql
+++ b/backend/internal/infra/store/schema.sql
@@ -13,6 +13,7 @@ CREATE TABLE IF NOT EXISTS jobs (
     id          TEXT PRIMARY KEY,
     analysis_id TEXT,
     status      TEXT NOT NULL,
+    phase       TEXT NOT NULL DEFAULT '',
     error       TEXT,
     created_at  DATETIME NOT NULL,
     updated_at  DATETIME NOT NULL,

--- a/frontend/src/pages/Analysis.tsx
+++ b/frontend/src/pages/Analysis.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { useJobStatus } from '@/hooks/useJobStatus'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import AnalysisGraphView from '@/pages/AnalysisGraphView'
+import type { JobPhase } from '@/types/api'
 
+// STEPS と PHASE_ORDER は同じ並び・同じ長さ。各ステップがバックエンドの 1 フェーズに対応する。
 const STEPS = [
   'リポジトリのクローン',
   '依存グラフの構築 (AST 解析)',
@@ -13,28 +14,21 @@ const STEPS = [
   '可視化の生成',
 ] as const
 
-const STEP_DURATIONS_MS = [2000, 4000, 6000, 9000]
+const PHASE_ORDER: JobPhase[] = ['clone', 'build_graph', 'diff', 'cluster', 'visualize']
 
 type StepStatus = 'done' | 'active' | 'pending'
 
-function useStepProgress(jobStatus: string | undefined): StepStatus[] {
-  const [elapsed, setElapsed] = useState(0)
+// stepStatuses はジョブの実フェーズから各ステップの表示状態を導出する（時間ベースの推測はしない）。
+function stepStatuses(jobStatus: string | undefined, phase: JobPhase | undefined): StepStatus[] {
+  if (jobStatus === 'done') return STEPS.map(() => 'done')
+  if (jobStatus === 'error') return STEPS.map(() => 'pending')
 
-  useEffect(() => {
-    if (jobStatus !== 'pending' && jobStatus !== 'running') return
-    const start = Date.now()
-    const id = setInterval(() => setElapsed(Date.now() - start), 500)
-    return () => clearInterval(id)
-  }, [jobStatus])
-
-  if (jobStatus === 'done' || jobStatus === 'error') {
-    return STEPS.map(() => (jobStatus === 'done' ? 'done' : 'pending'))
-  }
-
+  // pending（キュー待ち）でフェーズ未設定なら全て pending。それ以外は現在フェーズまでを done/active。
+  const current = phase ? PHASE_ORDER.indexOf(phase) : -1
   return STEPS.map((_, i) => {
-    if (i < STEPS.length - 1 && elapsed > STEP_DURATIONS_MS[i]) return 'done'
-    const prevDone = i === 0 || elapsed > STEP_DURATIONS_MS[i - 1]
-    if (prevDone) return 'active'
+    if (current < 0) return 'pending'
+    if (i < current) return 'done'
+    if (i === current) return 'active'
     return 'pending'
   })
 }
@@ -46,7 +40,7 @@ function isNoPackagesError(msg: string | undefined) {
 export default function Analysis() {
   const { jobId } = useParams<{ jobId: string }>()
   const { data: job, isLoading } = useJobStatus(jobId ?? '')
-  const stepStatuses = useStepProgress(job?.status)
+  const steps = stepStatuses(job?.status, job?.phase)
 
   if (isLoading || !job) {
     return (
@@ -100,7 +94,7 @@ export default function Analysis() {
         <Card className="border-stone-200">
           <CardContent className="px-0 py-1">
             {STEPS.map((label, i) => {
-              const s = stepStatuses[i]
+              const s = steps[i]
               return (
                 <div
                   key={label}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,6 +1,11 @@
+// JobPhase は running 中のジョブの現在フェーズ（バックエンドの実処理と連動）。
+// 配列順が解析パイプラインの進行順と一致する。
+export type JobPhase = 'clone' | 'build_graph' | 'diff' | 'cluster' | 'visualize'
+
 export type JobResponse = {
   job_id: string
   status: 'pending' | 'running' | 'done' | 'error'
+  phase?: JobPhase
   analysis_id?: string
   error?: string
 }


### PR DESCRIPTION
## 概要

解析中画面の5ステップ進捗インジケータが**時間ベースの偽進捗**（経過秒数のしきい値で進む）になっていた問題を解消する。バックエンドが解析パイプラインの実フェーズを永続化・API 露出し、フロントはそれを基にステップ表示を導出する。

Closes #66

## 変更内容

### バックエンド
- `domain.Job` に `Phase`（`JobPhase`: `clone` / `build_graph` / `diff` / `cluster` / `visualize`）を追加
- worker が各段階で `UpdatePhase` を呼んで実フェーズを記録
  - クローン→グラフ構築の遷移は base/head 並列のため `sync.Once` で先着のみ反映
- `jobs.phase` 列を schema + 起動時 `migrate`（既存 DB は冪等な `ALTER TABLE`）に追加
- `GET /api/jobs/:id` が `phase` を返す

### フロントエンド
- 時間ベースの偽進捗（`STEP_DURATIONS_MS` + 経過秒タイマー）を撤去
- ポーリングで取得した `job.phase` から各ステップの done / active / pending を導出（5ステップ＝5フェーズで1:1対応）

### ドキュメント
- backend はソースを bind mount せずイメージに焼き込むため、変更反映には `docker compose up -d --build backend` が必要な点を CLAUDE.md の作業フローに追記

## フェーズとステップの対応

| ステップ表示 | JobPhase | worker の処理 |
|---|---|---|
| リポジトリのクローン | `clone` | GetPR / ListChangedGoFiles / Prepare |
| 依存グラフの構築 (AST 解析) | `build_graph` | cgBuilder.Build |
| 差分との突き合わせ | `diff` | MergeWithDiffStatus / DetectNewCycles |
| クラスタ分類（4-way） | `cluster` | clusterer.Cluster |
| 可視化の生成 | `visualize` | CollectDiffFiles / Save |

## Test plan

- [x] バックエンド: `gofmt` / `go vet` クリーン
- [x] バックエンド: `go test ./...` 全パス（worker のフェーズ順序検証を追加）
- [x] フロントエンド: `npm run lint` / `tsc -b` / `prettier` クリーン
- [x] 実機ブラウザ: 解析を実行し、ステップが clone → build_graph → diff → cluster → visualize の順に進むことを確認
- [x] 既存 DB でも起動時 migration で `jobs.phase` が追加されることを確認

## 補足
- ポーリングは 1.5 秒間隔のため、解析が数秒未満で終わる極小 PR では中間フェーズを観測しきれず一部ステップが一瞬で飛ぶことがある（実フェーズ連動の必然で、偽進捗のような演出は行わない）