### PR TITLE
feat: ノードからコードジャンプ・循環参照ハイライト・レビュー優先度 (#29)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -145,7 +145,7 @@ ID やファイルパスは必ず mono にする。視認性と「これはコ�
 |---|---|
 | `PRMetaBar` | 上部固定バー。PR タイトル・ブランチ情報・ユーザー情報 |
 | `DependencyGraph` | `@xyflow/react` ベースの呼び出しグラフ |
-| `FunctionNode` / `FileNode` | グラフ上のノード。`changed=true` で `ring-amber-400` |
+| `FunctionNode` / `FileNode` | グラフ上のノード。リング優先度: 選択(stone-900) > 新規循環(red-500) > 追加(emerald-500) > 変更(amber-400)。新規循環ノードは右下に赤い ↻ バッジ |
 | `ClusterGroup` | 展開中クラスタの背景コンテナ。子ノードを `parentId` で内包 |
 | `SuperClusterNode` | 折りたたみ中クラスタのスーパーノード。クリックで展開 |
 | `FunctionDetailsPanel` | 右パネル。クラスタラベル・レイヤー・GitHub 該当行リンク・diff |
@@ -161,6 +161,12 @@ ID やファイルパスは必ず mono にする。視認性と「これはコ�
   - 呼び出し元（upstream caller, 選択ノードを呼ぶ側）: blue `#3b82f6`
   - 呼び出し先（downstream callee, 選択ノードが呼ぶ側）: orange `#f97316`
 - フォーカス計算（1-hop 近傍）は純粋関数 `computeFocus` に切り出し、レイアウト/描画から分離している。
+
+### 3.7 循環参照ハイライトとレビュー優先度
+
+- **循環参照ハイライト**: 新規循環（`is_new`）に属するノードは red-500 リング + 右下 ↻ バッジ、その内部辺（同一循環内の from→to）は red-500 の太線で強調する。既存循環は強調しない（PR で新たに生じた構造リスクのみ可視化する方針）。クラスタ折りたたみ時は循環がスーパーノード内に隠れるため、展開して確認する（段階的開示）。`CycleAlert` は新規循環の索引としてクリックでフォーカスする導線を兼ねる。
+- **レビュー優先度**: ノード選択時に詳細パネルへ `優先度 高/中/低` バッジを出す（グラフ上には出さない＝情報過多を避ける）。判定は `src/lib/reviewPriority.ts` の純粋関数: 高=新規循環に含まれる or（PR 変更ノードかつ被呼び出し数 `in-degree >= 3`）、中=その他の PR 変更ノード、低=未変更。色は 高=red / 中=amber / 低=stone。
+- **GitHub 行リンク**: 詳細パネルから定義行の GitHub blob URL を新規タブで開く（`src/lib/githubLinks.ts`）。`removed` は base SHA、それ以外は head SHA を ref に使う。
 
 ### 3.5 採用ライブラリ（外観に影響するもの）
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -148,7 +148,7 @@ ID やファイルパスは必ず mono にする。視認性と「これはコ�
 | `FunctionNode` / `FileNode` | グラフ上のノード。`changed=true` で `ring-amber-400` |
 | `ClusterGroup` | 展開中クラスタの背景コンテナ。子ノードを `parentId` で内包 |
 | `SuperClusterNode` | 折りたたみ中クラスタのスーパーノード。クリックで展開 |
-| `FunctionDetailsPanel` | 右パネル。クラスタラベル・レイヤー・diff |
+| `FunctionDetailsPanel` | 右パネル。クラスタラベル・レイヤー・GitHub 該当行リンク・diff |
 | `FocusLegend` | フォーカスモード中に左上に出る凡例（呼び出し元/先の方向色と件数） |
 | `DiffViewer` | `@monaco-editor/react` で before/after 表示 |
 | `ClusterSidebar` | クラスタ一覧（実装位置: `layout/`） |

--- a/backend/internal/api/dto.go
+++ b/backend/internal/api/dto.go
@@ -29,6 +29,8 @@ type PRInfoDTO struct {
 	Title   string `json:"title"`
 	BaseRef string `json:"base_ref"`
 	HeadRef string `json:"head_ref"`
+	BaseSHA string `json:"base_sha"`
+	HeadSHA string `json:"head_sha"`
 }
 
 // GraphResponse は GET /api/graph/:jobId のレスポンス
@@ -165,6 +167,8 @@ func toGraphResponse(a *domain.Analysis) GraphResponse {
 			Title:   a.PR.Title,
 			BaseRef: a.PR.BaseRef,
 			HeadRef: a.PR.HeadRef,
+			BaseSHA: a.PR.BaseSHA,
+			HeadSHA: a.PR.HeadSHA,
 		},
 		Clusters: clusters,
 		Graph:    GraphDTO{Nodes: nodes, Edges: edges},

--- a/backend/internal/usecase/regroup_test.go
+++ b/backend/internal/usecase/regroup_test.go
@@ -70,14 +70,29 @@ func TestRegroupBy_File(t *testing.T) {
 	}
 }
 
-func TestApplyClusterMode_LouvainPassthrough(t *testing.T) {
+func TestApplyClusterMode_LouvainLabelsClusters(t *testing.T) {
 	orig := &domain.ClusterResult{
-		Clusters: []domain.Cluster{{ID: 0, Label: "kept", Nodes: []domain.NodeID{"a"}}},
+		Clusters: []domain.Cluster{{ID: 0, Label: "raw", Nodes: []domain.NodeID{"a", "b"}}},
 		Graph:    sampleGraph(),
+		Cycles:   []domain.Cycle{{ID: 3, Nodes: []domain.NodeID{"a", "b"}, IsNew: true}},
 	}
 	got := applyClusterMode(orig, domain.ClusterModeLouvain)
-	if got != orig {
-		t.Error("Louvain mode should return the original result pointer unchanged")
+	if got == nil {
+		t.Fatal("Louvain mode returned nil")
+	}
+	// Louvain モードはクラスタ構成（ノードの所属）を変えずにラベルだけ付け直す。
+	if len(got.Clusters) != 1 || len(got.Clusters[0].Nodes) != 2 {
+		t.Errorf("clusters should be preserved, got %+v", got.Clusters)
+	}
+	if got.Clusters[0].Label == "raw" {
+		t.Error("Louvain mode should relabel clusters via labelClusters, but kept the input label")
+	}
+	// Graph と Cycles はそのまま保持される。
+	if len(got.Graph.Nodes) != len(orig.Graph.Nodes) {
+		t.Errorf("Graph not preserved: got %d nodes, want %d", len(got.Graph.Nodes), len(orig.Graph.Nodes))
+	}
+	if len(got.Cycles) != 1 || got.Cycles[0].ID != 3 {
+		t.Errorf("Cycles not preserved: %+v", got.Cycles)
 	}
 }
 

--- a/frontend/src/components/graph/FunctionDetailsPanel.tsx
+++ b/frontend/src/components/graph/FunctionDetailsPanel.tsx
@@ -1,6 +1,7 @@
 import type { AnyFlowNode, LayerKind } from '@/types/graph'
-import type { Cluster, DiffFile } from '@/types/api'
+import type { Cluster, DiffFile, PRInfo } from '@/types/api'
 import { getClusterColor } from '@/lib/clusterColors'
+import { buildBlobUrl } from '@/lib/githubLinks'
 import DiffViewer from '@/components/diff/DiffViewer'
 
 const LAYER_LABELS: Record<LayerKind, string> = {
@@ -16,14 +17,16 @@ type Props = {
   cluster: Cluster | null
   layer: LayerKind
   diff: DiffFile | undefined
+  pr: PRInfo
   onClose: () => void
 }
 
-export default function FunctionDetailsPanel({ node, cluster, layer, diff, onClose }: Props) {
+export default function FunctionDetailsPanel({ node, cluster, layer, diff, pr, onClose }: Props) {
   if (!node || node.type !== 'function') return null
 
   const color = cluster ? getClusterColor(cluster.id) : null
   const changed = node.data.changed as boolean
+  const blobUrl = buildBlobUrl(pr, node.data.file, node.data.line, node.data.diffStatus)
 
   return (
     <div
@@ -73,9 +76,37 @@ export default function FunctionDetailsPanel({ node, cluster, layer, diff, onClo
           <p className="break-all text-base font-bold text-stone-900">{node.data.label}</p>
           <p className="mt-1 break-all font-mono text-xs text-stone-500">{node.data.packagePath}</p>
         </div>
-        <p className="font-mono text-xs text-stone-400">
-          {node.data.file.split('/').pop()}:{node.data.line}
-        </p>
+        <div className="flex items-center justify-between gap-2">
+          <p className="break-all font-mono text-xs text-stone-400">
+            {node.data.file.split('/').pop()}:{node.data.line}
+          </p>
+          {blobUrl && (
+            <a
+              href={blobUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex flex-shrink-0 items-center gap-1 text-xs font-medium text-teal-600 hover:text-teal-700 hover:underline"
+              title="GitHub で該当行を開く"
+            >
+              <svg
+                width="13"
+                height="13"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                <polyline points="15 3 21 3 21 9" />
+                <line x1="10" y1="14" x2="21" y2="3" />
+              </svg>
+              GitHub
+            </a>
+          )}
+        </div>
       </div>
 
       {diff ? (

--- a/frontend/src/components/graph/FunctionDetailsPanel.tsx
+++ b/frontend/src/components/graph/FunctionDetailsPanel.tsx
@@ -1,5 +1,6 @@
 import type { AnyFlowNode, LayerKind } from '@/types/graph'
 import type { Cluster, DiffFile, PRInfo } from '@/types/api'
+import type { ReviewPriority } from '@/lib/reviewPriority'
 import { getClusterColor } from '@/lib/clusterColors'
 import { buildBlobUrl } from '@/lib/githubLinks'
 import DiffViewer from '@/components/diff/DiffViewer'
@@ -12,20 +13,42 @@ const LAYER_LABELS: Record<LayerKind, string> = {
   other: 'Other',
 }
 
+const PRIORITY_LABELS: Record<ReviewPriority, string> = {
+  high: '高',
+  medium: '中',
+  low: '低',
+}
+
+const PRIORITY_CLASSES: Record<ReviewPriority, string> = {
+  high: 'bg-red-100 text-red-700',
+  medium: 'bg-amber-100 text-amber-700',
+  low: 'bg-stone-100 text-stone-500',
+}
+
 type Props = {
   node: AnyFlowNode | null
   cluster: Cluster | null
   layer: LayerKind
   diff: DiffFile | undefined
   pr: PRInfo
+  priority: ReviewPriority
   onClose: () => void
 }
 
-export default function FunctionDetailsPanel({ node, cluster, layer, diff, pr, onClose }: Props) {
+export default function FunctionDetailsPanel({
+  node,
+  cluster,
+  layer,
+  diff,
+  pr,
+  priority,
+  onClose,
+}: Props) {
   if (!node || node.type !== 'function') return null
 
   const color = cluster ? getClusterColor(cluster.id) : null
   const changed = node.data.changed as boolean
+  const inCycle = node.data.inCycle as boolean
   const blobUrl = buildBlobUrl(pr, node.data.file, node.data.line, node.data.diffStatus)
 
   return (
@@ -54,6 +77,12 @@ export default function FunctionDetailsPanel({ node, cluster, layer, diff, pr, o
 
       <div className="p-4 space-y-4 border-b border-stone-100">
         <div className="flex flex-wrap gap-1.5">
+          <span
+            className={`rounded-full px-2 py-0.5 text-xs font-medium ${PRIORITY_CLASSES[priority]}`}
+            title="レビュー優先度（新規循環・変更・被呼び出し数から算出）"
+          >
+            優先度 {PRIORITY_LABELS[priority]}
+          </span>
           {cluster && color && (
             <span
               className="rounded-full px-2 py-0.5 text-xs font-medium"
@@ -68,6 +97,11 @@ export default function FunctionDetailsPanel({ node, cluster, layer, diff, pr, o
           {changed && (
             <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
               changed
+            </span>
+          )}
+          {inCycle && (
+            <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700">
+              循環参照
             </span>
           )}
         </div>

--- a/frontend/src/components/graph/FunctionNode.tsx
+++ b/frontend/src/components/graph/FunctionNode.tsx
@@ -4,6 +4,7 @@ import type { FunctionFlowNode } from '@/types/graph'
 export default function FunctionNode({ data, selected }: NodeProps<FunctionFlowNode>) {
   const isAdded = data.diffStatus === 'added'
   const isRemoved = data.diffStatus === 'removed'
+  const inCycle = data.inCycle
   return (
     <div
       className={[
@@ -11,8 +12,9 @@ export default function FunctionNode({ data, selected }: NodeProps<FunctionFlowN
         'w-[200px]',
         isRemoved ? 'border-dashed border-stone-300 opacity-60 grayscale' : 'border-stone-200',
         selected ? 'ring-2 ring-stone-900' : '',
-        !selected && isAdded ? 'ring-2 ring-emerald-500' : '',
-        !selected && !isAdded && data.changed ? 'ring-2 ring-amber-400' : '',
+        !selected && inCycle ? 'ring-2 ring-red-500' : '',
+        !selected && !inCycle && isAdded ? 'ring-2 ring-emerald-500' : '',
+        !selected && !inCycle && !isAdded && data.changed ? 'ring-2 ring-amber-400' : '',
       ]
         .filter(Boolean)
         .join(' ')}
@@ -39,6 +41,14 @@ export default function FunctionNode({ data, selected }: NodeProps<FunctionFlowN
       )}
       {!isAdded && !isRemoved && data.changed && (
         <div className="absolute right-1.5 top-1.5 size-2 rounded-full bg-amber-400" />
+      )}
+      {inCycle && (
+        <div
+          className="absolute bottom-1.5 right-1.5 flex size-3.5 items-center justify-center rounded-full bg-red-500 text-[10px] font-bold leading-none text-white"
+          title="新規循環参照に含まれる"
+        >
+          ↻
+        </div>
       )}
       <div className="pl-3 pr-4 py-2">
         <p

--- a/frontend/src/lib/githubLinks.ts
+++ b/frontend/src/lib/githubLinks.ts
@@ -1,0 +1,23 @@
+import type { DiffStatus, PRInfo } from '@/types/api'
+
+// buildBlobUrl はノードの定義位置を指す GitHub blob URL を組み立てる。
+//
+// file はリポジトリルート相対パス（バックエンドが filepath.Rel(repoRoot, ...) で算出）。
+// removed ノードの定義行は base 側にしか存在しないため base SHA を、
+// それ以外（added / existing）は head SHA を ref に使う。
+// SHA が空の場合はブランチ ref にフォールバックし、ref が一切無ければ null を返す。
+export function buildBlobUrl(
+  pr: PRInfo,
+  file: string,
+  line: number,
+  diffStatus: DiffStatus,
+): string | null {
+  if (!file) return null
+
+  const ref = diffStatus === 'removed' ? pr.base_sha || pr.base_ref : pr.head_sha || pr.head_ref
+  if (!ref) return null
+
+  const path = file.split('/').map(encodeURIComponent).join('/')
+  const base = `https://github.com/${pr.owner}/${pr.repo}/blob/${ref}/${path}`
+  return line > 0 ? `${base}#L${line}` : base
+}

--- a/frontend/src/lib/graphLayout.ts
+++ b/frontend/src/lib/graphLayout.ts
@@ -54,6 +54,9 @@ function mergeEdgeStatus(a: DiffStatus, b: DiffStatus): DiffStatus {
   return 'existing'
 }
 
+// 新規循環参照を構成するエッジの強調色（red-500）。diff の色より優先する。
+const CYCLE_EDGE_COLOR = '#ef4444'
+
 function edgeColorByStatus(status: DiffStatus): string {
   switch (status) {
     case 'added':
@@ -84,6 +87,14 @@ function edgeMarkerByStatus(status: DiffStatus): EdgeMarker {
   return { type: MarkerType.ArrowClosed, color: edgeColorByStatus(status), width: 16, height: 16 }
 }
 
+// 新規循環参照を構成するエッジのスタイル / マーカー（赤・太線）。
+function cycleEdgeStyle(): CSSProperties {
+  return { stroke: CYCLE_EDGE_COLOR, strokeWidth: 2.5 }
+}
+function cycleEdgeMarker(): EdgeMarker {
+  return { type: MarkerType.ArrowClosed, color: CYCLE_EDGE_COLOR, width: 16, height: 16 }
+}
+
 export function layoutGraph(data: GraphResponse, expandedClusters: Set<string>): LayoutResult {
   const inputNodes: InputNode[] = data.graph.nodes.map((n) => ({
     id: n.id,
@@ -100,6 +111,15 @@ export function layoutGraph(data: GraphResponse, expandedClusters: Set<string>):
   }))
   const inputEdges: GraphEdge[] = data.graph.edges
   const clusters: Cluster[] = data.clusters
+
+  // 新規循環参照（is_new）に属するノード集合と、同一循環内のノード対集合を作る。
+  // ノード強調用に集合、エッジ強調用に各循環のノードセットを持つ。
+  const newCycleSets = data.cycles.filter((c) => c.is_new).map((c) => new Set(c.nodes))
+  const cycleNodeIds = new Set<string>()
+  for (const s of newCycleSets) for (const id of s) cycleNodeIds.add(id)
+  // エッジ (from→to) が同一の新規循環の内部辺なら true。
+  const isCycleEdge = (from: string, to: string): boolean =>
+    newCycleSets.some((s) => s.has(from) && s.has(to))
 
   const nodeToCluster = new Map<string, number>()
   for (const c of clusters) {
@@ -125,6 +145,8 @@ export function layoutGraph(data: GraphResponse, expandedClusters: Set<string>):
   // Build edges with cluster aggregation. DiffStatus は added > removed > existing で昇格。
   const edgeStatusMap = new Map<string, DiffStatus>()
   const edgeKeyToFromTo = new Map<string, { source: string; target: string }>()
+  // 集約後のエッジが新規循環の内部辺を1本でも含むなら強調する。
+  const edgeCycleMap = new Map<string, boolean>()
 
   for (const e of inputEdges) {
     const fromNode = nodeMap.get(e.from)
@@ -147,18 +169,20 @@ export function layoutGraph(data: GraphResponse, expandedClusters: Set<string>):
     if (!edgeKeyToFromTo.has(edgeKey)) {
       edgeKeyToFromTo.set(edgeKey, { source: srcId, target: dstId })
     }
+    if (isCycleEdge(e.from, e.to)) edgeCycleMap.set(edgeKey, true)
   }
 
   const flowEdges: Edge[] = []
   for (const [edgeKey, status] of edgeStatusMap.entries()) {
     const ft = edgeKeyToFromTo.get(edgeKey)!
+    const inCycle = edgeCycleMap.get(edgeKey) ?? false
     flowEdges.push({
       id: `e:${edgeKey}`,
       source: ft.source,
       target: ft.target,
-      style: edgeStyleByStatus(status),
-      markerEnd: edgeMarkerByStatus(status),
-      data: { diffStatus: status },
+      style: inCycle ? cycleEdgeStyle() : edgeStyleByStatus(status),
+      markerEnd: inCycle ? cycleEdgeMarker() : edgeMarkerByStatus(status),
+      data: { diffStatus: status, inCycle },
     })
   }
 
@@ -260,6 +284,7 @@ export function layoutGraph(data: GraphResponse, expandedClusters: Set<string>):
               line: n.line,
               changed: n.changed,
               diffStatus: n.diffStatus,
+              inCycle: cycleNodeIds.has(n.id),
               clusterId: cid,
               clusterColorHex: color.hex,
               layer,

--- a/frontend/src/lib/reviewPriority.ts
+++ b/frontend/src/lib/reviewPriority.ts
@@ -1,0 +1,42 @@
+import type { Cycle, DiffStatus, GraphEdge } from '@/types/api'
+
+// レビュー優先度。レビュアーがどのノードを重点的に見るべきかの指標。
+export type ReviewPriority = 'high' | 'medium' | 'low'
+
+// 「高」と判定する被呼び出し数（in-degree）のしきい値。
+// これ以上の呼び出し元を持つ変更ノードは影響範囲が広いとみなす。
+export const HIGH_IN_DEGREE = 3
+
+// computeInDegree は各ノードの被呼び出し数（呼び出し元の数）を集計する。
+export function computeInDegree(edges: GraphEdge[]): Map<string, number> {
+  const m = new Map<string, number>()
+  for (const e of edges) m.set(e.to, (m.get(e.to) ?? 0) + 1)
+  return m
+}
+
+// newCycleNodeIds は新規循環参照（is_new）に属する全ノード ID 集合を返す。
+export function newCycleNodeIds(cycles: Cycle[]): Set<string> {
+  const s = new Set<string>()
+  for (const c of cycles) {
+    if (!c.is_new) continue
+    for (const n of c.nodes) s.add(n)
+  }
+  return s
+}
+
+// computeReviewPriority はノード単体の優先度を決める。
+//
+// 高: 新規循環に含まれる、または PR で変更され被呼び出し数が多い（影響範囲が広い）
+// 中: PR で変更されたが上記に当たらない
+// 低: PR で変更されていない（レビューの主対象ではない文脈ノード）
+export function computeReviewPriority(
+  node: { changed: boolean; diff_status: DiffStatus },
+  inDegree: number,
+  inNewCycle: boolean,
+): ReviewPriority {
+  if (inNewCycle) return 'high'
+  const touched = node.changed || node.diff_status !== 'existing'
+  if (!touched) return 'low'
+  if (inDegree >= HIGH_IN_DEGREE) return 'high'
+  return 'medium'
+}

--- a/frontend/src/pages/AnalysisGraphView.tsx
+++ b/frontend/src/pages/AnalysisGraphView.tsx
@@ -7,6 +7,12 @@ import { useDiff } from '@/hooks/useDiff'
 import { inferLayer } from '@/lib/layerInference'
 import { getClusterColor } from '@/lib/clusterColors'
 import { makeClusterKey } from '@/lib/graphLayout'
+import {
+  computeInDegree,
+  computeReviewPriority,
+  newCycleNodeIds,
+  type ReviewPriority,
+} from '@/lib/reviewPriority'
 import AppShell from '@/components/layout/AppShell'
 import PRMetaBar from '@/components/layout/PRMetaBar'
 import DependencyGraph from '@/components/graph/DependencyGraph'
@@ -105,23 +111,34 @@ export default function AnalysisGraphView({ jobId }: Props) {
     [data, defaultExpandedClusters],
   )
 
-  const { panelNode, selectedCluster, selectedLayer, panelDiff } = useMemo(() => {
-    if (!data || !selectedNodeId) {
-      return {
-        panelNode: null,
-        selectedCluster: null,
-        selectedLayer: 'other' as LayerKind,
-        panelDiff: undefined as DiffFile | undefined,
-      }
+  // in-degree（被呼び出し数）と新規循環ノード集合はグラフ全体から一度だけ算出する。
+  const { inDegree, cycleNodeIds } = useMemo(
+    () => ({
+      inDegree: data ? computeInDegree(data.graph.edges) : new Map<string, number>(),
+      cycleNodeIds: data ? newCycleNodeIds(data.cycles) : new Set<string>(),
+    }),
+    [data],
+  )
+
+  const { panelNode, selectedCluster, selectedLayer, panelDiff, panelPriority } = useMemo(() => {
+    const empty = {
+      panelNode: null,
+      selectedCluster: null,
+      selectedLayer: 'other' as LayerKind,
+      panelDiff: undefined as DiffFile | undefined,
+      panelPriority: 'low' as ReviewPriority,
     }
+    if (!data || !selectedNodeId) return empty
 
     const gn = data.graph.nodes.find((n) => n.id === selectedNodeId)
-    if (!gn) return { panelNode: null, selectedCluster: null, selectedLayer: 'other' as LayerKind }
+    if (!gn) return empty
 
     const layer = inferLayer(gn.package)
     const cluster: Cluster | null = data.clusters.find((c) => c.nodes.includes(gn.id)) ?? null
     const cid = cluster?.id ?? 0
     const color = getClusterColor(cid)
+    const inCycle = cycleNodeIds.has(gn.id)
+    const priority = computeReviewPriority(gn, inDegree.get(gn.id) ?? 0, inCycle)
 
     const node: AnyFlowNode = {
       id: gn.id,
@@ -134,6 +151,7 @@ export default function AnalysisGraphView({ jobId }: Props) {
         line: gn.line,
         changed: gn.changed,
         diffStatus: gn.diff_status,
+        inCycle,
         clusterId: cid,
         clusterColorHex: color.hex,
         layer,
@@ -142,8 +160,14 @@ export default function AnalysisGraphView({ jobId }: Props) {
     const funcDiff = diffData?.files.find(
       (f) => gn.file === f.filename || gn.file.endsWith('/' + f.filename),
     )
-    return { panelNode: node, selectedCluster: cluster, selectedLayer: layer, panelDiff: funcDiff }
-  }, [data, diffData, selectedNodeId])
+    return {
+      panelNode: node,
+      selectedCluster: cluster,
+      selectedLayer: layer,
+      panelDiff: funcDiff,
+      panelPriority: priority,
+    }
+  }, [data, diffData, selectedNodeId, inDegree, cycleNodeIds])
 
   if (isLoading) {
     return (
@@ -187,6 +211,7 @@ export default function AnalysisGraphView({ jobId }: Props) {
             layer={selectedLayer}
             diff={panelDiff}
             pr={data.pr}
+            priority={panelPriority}
             onClose={() => setSelectedNodeId(null)}
           />
         ) : undefined

--- a/frontend/src/pages/AnalysisGraphView.tsx
+++ b/frontend/src/pages/AnalysisGraphView.tsx
@@ -186,6 +186,7 @@ export default function AnalysisGraphView({ jobId }: Props) {
             cluster={selectedCluster}
             layer={selectedLayer}
             diff={panelDiff}
+            pr={data.pr}
             onClose={() => setSelectedNodeId(null)}
           />
         ) : undefined

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -17,6 +17,8 @@ export type PRInfo = {
   title: string
   base_ref: string
   head_ref: string
+  base_sha: string
+  head_sha: string
 }
 
 export type DiffStatus = 'added' | 'removed' | 'existing'

--- a/frontend/src/types/graph.ts
+++ b/frontend/src/types/graph.ts
@@ -10,6 +10,7 @@ export type FunctionNodeData = {
   line: number
   changed: boolean
   diffStatus: DiffStatus
+  inCycle: boolean
   clusterId: number
   clusterColorHex: string
   layer: LayerKind


### PR DESCRIPTION
## 概要
#29「グラフノードクリックで該当コードへジャンプ・危険箇所ハイライト」を実装。3要素すべてをこのブランチで対応した。グラフを「見る」だけのツールから、レビュアーのアクションにつながる導線を持つツールへ進める。

## 変更内容

### 1. コードジャンプ（GitHub 行リンク）
- 詳細パネルに該当ファイル・行の GitHub blob URL を新規タブで開くリンクを追加
- `GraphResponse` に `base_sha` / `head_sha` を追加（パーマリンク用 ref）
- `removed` ノードは base SHA、それ以外は head SHA を ref に使う（SHA 空時はブランチ ref にフォールバック）
- File はリポジトリルート相対（`Build` が `RepoRoot` 基点で算出）なので blob URL にそのまま使える

### 2. 新規循環参照のグラフ強調
- 新規循環（`is_new`）のノードを red リング + 右下 ↻ バッジ、内部辺を赤太線で強調
- 既存循環は強調しない（PR で新たに生じた構造リスクのみ可視化する方針）
- クラスタ折りたたみ時は循環がスーパーノード内に隠れるため、展開して確認（段階的開示）

### 3. レビュー優先度
- ノード選択時に詳細パネルへ `優先度 高/中/低` バッジを表示（グラフ上には出さず情報過多を回避）
- 判定（`src/lib/reviewPriority.ts` の純粋関数）: 高=新規循環に含まれる or（PR 変更ノードかつ被呼び出し数 `in-degree >= 3`）、中=その他の PR 変更ノード、低=未変更

### その他
- develop 由来の壊れテスト `TestApplyClusterMode_LouvainPassthrough` を実挙動（ラベル付け直し + Graph/Cycles 保持）に合わせて修正（refactor #64 以降ポインタ同一性が成立しなくなっていた）
- `DESIGN.md` を更新（3.4 / 3.7）

## ゲート
- backend: `gofmt`/`go vet` クリーン、`go test ./...` 全 green
- frontend: `npm run lint` / `tsc -b` / `prettier` 全 green

## Test plan（実機ブラウザ確認 — CLI では未確認）
- [x] ノードを選択 → 詳細パネルの「GitHub」リンクが正しい行（`#L<line>`）を新規タブで開く
- [x] added / existing ノードは head、removed ノードは base のコードへ飛ぶ
- [x] fork PR でも head SHA で正しく開ける
- [x] 新規循環を含む PR で、循環ノードに赤リング + ↻ バッジ、内部辺が赤太線で表示される
- [x] クラスタ折りたたみ時は循環がスーパーノード内に隠れ、展開で再表示される
- [x] 詳細パネルの優先度バッジが基準どおり（循環ノード=高 / 被呼び出し多い変更ノード=高 / 未変更=低）
- [x] DevTools コンソールにエラー・警告が出ない

## 残課題
- #30（AI によるアンチパターン指摘）は本 PR の循環検出・レビュー導線を前提に別途着手
