### PR TITLE
fix: 解析結果に PR メタ情報を永続化し GitHub 定義行リンクを表示

### DIFF
--- a/backend/internal/infra/store/analysis_repo.go
+++ b/backend/internal/infra/store/analysis_repo.go
@@ -39,8 +39,12 @@ func (r *AnalysisRepo) Save(ctx context.Context, a *domain.Analysis) error {
 		return fmt.Errorf("marshal analysis result: %w", err)
 	}
 	_, err = r.db.ExecContext(ctx,
-		`INSERT INTO analyses (id, owner, repo, pr_number, result, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
-		string(a.ID), a.PR.Owner, a.PR.Repo, a.PR.Number, string(resultJSON), a.CreatedAt.UTC(),
+		`INSERT INTO analyses
+		 (id, owner, repo, pr_number, pr_title, pr_base_ref, pr_head_ref, pr_base_sha, pr_head_sha, result, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		string(a.ID), a.PR.Owner, a.PR.Repo, a.PR.Number,
+		a.PR.Title, a.PR.BaseRef, a.PR.HeadRef, a.PR.BaseSHA, a.PR.HeadSHA,
+		string(resultJSON), a.CreatedAt.UTC(),
 	)
 	if err != nil {
 		return fmt.Errorf("insert analysis: %w", err)
@@ -54,13 +58,19 @@ func (r *AnalysisRepo) FindByID(ctx context.Context, id domain.AnalysisID) (*dom
 		owner      string
 		repo       string
 		prNumber   int
+		prTitle    string
+		prBaseRef  string
+		prHeadRef  string
+		prBaseSHA  string
+		prHeadSHA  string
 		resultJSON string
 		createdAt  time.Time
 	)
 	err := r.db.QueryRowContext(ctx,
-		`SELECT owner, repo, pr_number, result, created_at FROM analyses WHERE id = ?`,
+		`SELECT owner, repo, pr_number, pr_title, pr_base_ref, pr_head_ref, pr_base_sha, pr_head_sha, result, created_at
+		 FROM analyses WHERE id = ?`,
 		string(id),
-	).Scan(&owner, &repo, &prNumber, &resultJSON, &createdAt)
+	).Scan(&owner, &repo, &prNumber, &prTitle, &prBaseRef, &prHeadRef, &prBaseSHA, &prHeadSHA, &resultJSON, &createdAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -73,8 +83,17 @@ func (r *AnalysisRepo) FindByID(ctx context.Context, id domain.AnalysisID) (*dom
 		return nil, fmt.Errorf("unmarshal analysis result: %w", err)
 	}
 	return &domain.Analysis{
-		ID:           id,
-		PR:           domain.PRInfo{Owner: owner, Repo: repo, Number: prNumber},
+		ID: id,
+		PR: domain.PRInfo{
+			Owner:   owner,
+			Repo:    repo,
+			Number:  prNumber,
+			Title:   prTitle,
+			BaseRef: prBaseRef,
+			HeadRef: prHeadRef,
+			BaseSHA: prBaseSHA,
+			HeadSHA: prHeadSHA,
+		},
 		Result:       result,
 		ChangedFiles: changedFiles,
 		CreatedAt:    createdAt,
@@ -85,13 +104,19 @@ func (r *AnalysisRepo) FindByID(ctx context.Context, id domain.AnalysisID) (*dom
 func (r *AnalysisRepo) FindByPR(ctx context.Context, pr domain.PRInfo) (*domain.Analysis, error) {
 	var (
 		id         string
+		prTitle    string
+		prBaseRef  string
+		prHeadRef  string
+		prBaseSHA  string
+		prHeadSHA  string
 		resultJSON string
 		createdAt  time.Time
 	)
 	err := r.db.QueryRowContext(ctx,
-		`SELECT id, result, created_at FROM analyses WHERE owner=? AND repo=? AND pr_number=? ORDER BY created_at DESC LIMIT 1`,
+		`SELECT id, pr_title, pr_base_ref, pr_head_ref, pr_base_sha, pr_head_sha, result, created_at
+		 FROM analyses WHERE owner=? AND repo=? AND pr_number=? ORDER BY created_at DESC LIMIT 1`,
 		pr.Owner, pr.Repo, pr.Number,
-	).Scan(&id, &resultJSON, &createdAt)
+	).Scan(&id, &prTitle, &prBaseRef, &prHeadRef, &prBaseSHA, &prHeadSHA, &resultJSON, &createdAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -104,8 +129,17 @@ func (r *AnalysisRepo) FindByPR(ctx context.Context, pr domain.PRInfo) (*domain.
 		return nil, fmt.Errorf("unmarshal analysis result: %w", err)
 	}
 	return &domain.Analysis{
-		ID:           domain.AnalysisID(id),
-		PR:           pr,
+		ID: domain.AnalysisID(id),
+		PR: domain.PRInfo{
+			Owner:   pr.Owner,
+			Repo:    pr.Repo,
+			Number:  pr.Number,
+			Title:   prTitle,
+			BaseRef: prBaseRef,
+			HeadRef: prHeadRef,
+			BaseSHA: prBaseSHA,
+			HeadSHA: prHeadSHA,
+		},
 		Result:       result,
 		ChangedFiles: changedFiles,
 		CreatedAt:    createdAt,

--- a/backend/internal/infra/store/analysis_repo_test.go
+++ b/backend/internal/infra/store/analysis_repo_test.go
@@ -31,8 +31,17 @@ func TestAnalysisRepo_SaveAndFindByID(t *testing.T) {
 		},
 	}
 	a := &domain.Analysis{
-		ID:        "test-analysis-id",
-		PR:        domain.PRInfo{Owner: "owner", Repo: "repo", Number: 42},
+		ID: "test-analysis-id",
+		PR: domain.PRInfo{
+			Owner:   "owner",
+			Repo:    "repo",
+			Number:  42,
+			Title:   "Add feature",
+			BaseRef: "main",
+			HeadRef: "feature-x",
+			BaseSHA: "base123",
+			HeadSHA: "head456",
+		},
 		Result:    result,
 		CreatedAt: time.Now().UTC().Truncate(time.Second),
 	}
@@ -50,6 +59,11 @@ func TestAnalysisRepo_SaveAndFindByID(t *testing.T) {
 	}
 	if got.PR.Owner != "owner" || got.PR.Repo != "repo" || got.PR.Number != 42 {
 		t.Errorf("PR mismatch: got %+v", got.PR)
+	}
+	// PR メタ情報（タイトル・ref・SHA）が round-trip すること（GitHub 定義行リンクの ref に使う）。
+	if got.PR.Title != "Add feature" || got.PR.BaseRef != "main" || got.PR.HeadRef != "feature-x" ||
+		got.PR.BaseSHA != "base123" || got.PR.HeadSHA != "head456" {
+		t.Errorf("PR metadata mismatch: got %+v", got.PR)
 	}
 	if len(got.Result.Clusters) != 1 || got.Result.Clusters[0].Label != "pkg/foo" {
 		t.Errorf("Clusters mismatch: got %+v", got.Result.Clusters)
@@ -143,7 +157,9 @@ func TestAnalysisRepo_FindByPR_ReturnsLatest(t *testing.T) {
 	emptyResult := &domain.ClusterResult{}
 
 	old := &domain.Analysis{ID: "old", PR: pr, Result: emptyResult, CreatedAt: time.Now().UTC().Add(-time.Hour)}
-	newer := &domain.Analysis{ID: "newer", PR: pr, Result: emptyResult, CreatedAt: time.Now().UTC()}
+	newerPR := pr
+	newerPR.HeadSHA = "head789"
+	newer := &domain.Analysis{ID: "newer", PR: newerPR, Result: emptyResult, CreatedAt: time.Now().UTC()}
 
 	for _, a := range []*domain.Analysis{old, newer} {
 		if err := repo.Save(ctx, a); err != nil {
@@ -160,6 +176,10 @@ func TestAnalysisRepo_FindByPR_ReturnsLatest(t *testing.T) {
 	}
 	if got.ID != "newer" {
 		t.Errorf("expected newest analysis, got id=%s", got.ID)
+	}
+	// 永続化された PR メタ情報（SHA）が引数 pr ではなく DB の値で復元されること。
+	if got.PR.HeadSHA != "head789" {
+		t.Errorf("expected persisted HeadSHA, got %q", got.PR.HeadSHA)
 	}
 }
 

--- a/backend/internal/infra/store/db.go
+++ b/backend/internal/infra/store/db.go
@@ -41,6 +41,13 @@ func migrate(db *sql.DB) error {
 	if err := addColumnIfNotExists(db, "jobs", "phase", "TEXT NOT NULL DEFAULT ''"); err != nil {
 		return err
 	}
+	// analyses に PR メタ情報（タイトル・ref・SHA）を後付けする。
+	// GitHub 定義行リンク / PR メタ表示は解析結果から復元するためここに永続化する。
+	for _, col := range []string{"pr_title", "pr_base_ref", "pr_head_ref", "pr_base_sha", "pr_head_sha"} {
+		if err := addColumnIfNotExists(db, "analyses", col, "TEXT NOT NULL DEFAULT ''"); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/backend/internal/infra/store/schema.sql
+++ b/backend/internal/infra/store/schema.sql
@@ -1,11 +1,16 @@
 -- analyses テーブル
 CREATE TABLE IF NOT EXISTS analyses (
-    id         TEXT PRIMARY KEY,
-    owner      TEXT NOT NULL,
-    repo       TEXT NOT NULL,
-    pr_number  INTEGER NOT NULL,
-    result     TEXT,    -- JSON
-    created_at DATETIME NOT NULL
+    id          TEXT PRIMARY KEY,
+    owner       TEXT NOT NULL,
+    repo        TEXT NOT NULL,
+    pr_number   INTEGER NOT NULL,
+    pr_title    TEXT NOT NULL DEFAULT '',
+    pr_base_ref TEXT NOT NULL DEFAULT '',
+    pr_head_ref TEXT NOT NULL DEFAULT '',
+    pr_base_sha TEXT NOT NULL DEFAULT '',
+    pr_head_sha TEXT NOT NULL DEFAULT '',
+    result      TEXT,    -- JSON
+    created_at  DATETIME NOT NULL
 );
 
 -- jobs テーブル


### PR DESCRIPTION
詳細パネルの GitHub リンク (#29) が表示されない不具合を修正する。

worker が GetPR で取得した PR の ref/SHA/title を Analysis.PR に 入れていたが、analyses テーブルにそれらの列が無く Save で破棄され、
GET /api/graph では FindByID が owner/repo/number だけで PR を復元 していた。結果 GraphResponse の base_sha/head_sha/base_ref/head_ref が常に空になり、フロントの buildBlobUrl が null を返してリンクが
描画されなかった（PRMetaBar のタイトル・ref 表示も同じ理由で欠落）。

- analyses に pr_title / pr_base_ref / pr_head_ref / pr_base_sha / pr_head_sha 列を追加（schema.sql + 既存 DB 向け migration）
- AnalysisRepo の Save / FindByID / FindByPR で PR メタ情報を往復
- FindByPR は引数 pr ではなく永続化値で ref/SHA を復元する