### PR TITLE
fix: Go workspace / 新バージョン要求リポジトリ(k8s 等)の解析誤判定を修正 (#76)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@
 - 作業ブランチは **`develop` から** 切る（`main` からではない）
 - タスクを一つ終わらせるごとにコミットする。
 - **コミット前にリンター・フォーマッター・テストを必ず通す**
-  - バックエンド（フォーマット + lint）: `docker run --rm -v $(pwd)/backend:/app -w /app golang:1.25 sh -c 'gofmt -w . && go vet ./...'`
+  - バックエンド（フォーマット + lint）: `docker run --rm -v $(pwd)/backend:/app -w /app golang:1.26 sh -c 'gofmt -w . && go vet ./...'`
   - バックエンド（テスト）: `docker compose run --build --rm backend go test ./...`
     - `backend` はソースを bind mount せず `compose.yml` の `build:` でイメージに焼き込む。`docker compose run` は `--build` を付けないとキャッシュ済みイメージを使い回し、変更したコードが反映されず**古いコードをテストしてしまう**（新規テストが `no tests to run` になる等で気づきにくい）。テスト時は必ず `--build` を付ける
   - フロントエンド: `docker compose run --rm frontend sh -c 'npm run lint && npx tsc -b && npx prettier --write .'`

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.25
+FROM golang:1.26
 RUN go install github.com/air-verse/air@latest
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/backend/internal/infra/analyzer/parser.go
+++ b/backend/internal/infra/analyzer/parser.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -14,8 +15,18 @@ import (
 	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
 )
 
-// ErrNoPackages はGo パッケージが1件も見つからなかったときのsentinel error。
+// ErrNoPackages は対象に Go パッケージ（.go ファイル / go.mod）が無く、
+// 「Go リポジトリではない」と判定してよいときの sentinel error。
 var ErrNoPackages = errors.New("analyzer: no Go packages found")
+
+// ErrGoToolchainUnavailable はリポジトリの go.mod が要求する Go バージョンの
+// toolchain を用意できなかったときの sentinel error（GOTOOLCHAIN=auto でも DL に失敗した等）。
+// 解析環境側の問題であり「Go リポジトリではない」とは区別する。
+var ErrGoToolchainUnavailable = errors.New("analyzer: required Go toolchain unavailable")
+
+// ErrPackageLoadFailed は go/packages のドライバ起動自体が失敗したときの sentinel error
+// （依存解決・vendoring 不整合など）。「Go パッケージ皆無」とは区別する。
+var ErrPackageLoadFailed = errors.New("analyzer: failed to load Go packages")
 
 // loadMode は callgraph (#5) と diff→AST マップ (#6) で必要なフラグを全て含む。
 const loadMode = packages.NeedName |
@@ -62,6 +73,89 @@ func NewGoPackageLoader() *GoPackageLoader {
 	return &GoPackageLoader{}
 }
 
+// analyzerEnv はパッケージロード時の環境変数を構築する。
+//
+//   - ホスト由来の GOWORK を除去し、go.work の解決を go の自動探索に委ねる。
+//     解析は clone した一時ディレクトリ内で完結するため、リポジトリ自身の go.work
+//     （例: Kubernetes の workspace 構成）は尊重しつつ、ホストの go.work は一時
+//     ディレクトリの祖先に無いので混入しない。以前は GOWORK=off を一律強制していたが、
+//     これは workspace vendoring と不整合になり依存解決を壊していた。
+//   - GOTOOLCHAIN=auto を明示し、ベースイメージが焼く GOTOOLCHAIN=local を上書きする。
+//     リポジトリの go.mod が要求する新しい Go を必要に応じて自動取得する。
+func analyzerEnv() []string {
+	src := os.Environ()
+	env := make([]string, 0, len(src)+1)
+	for _, kv := range src {
+		if strings.HasPrefix(kv, "GOWORK=") || strings.HasPrefix(kv, "GOTOOLCHAIN=") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	return append(env, "GOTOOLCHAIN=auto")
+}
+
+// classifyLoadErr は packages.Load のトップレベルエラーを sentinel に分類する。
+// toolchain バージョンの入手失敗・go.mod 不在（＝Go リポジトリではない）・その他の
+// ロード失敗を区別し、frontend が原因に応じた文言を出せるようにする。
+func classifyLoadErr(err error) error {
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "toolchain not available"),
+		strings.Contains(msg, "requires go >="),
+		strings.Contains(msg, "GOTOOLCHAIN"):
+		return fmt.Errorf("%w: %w", ErrGoToolchainUnavailable, err)
+	case strings.Contains(msg, "does not contain main module"),
+		strings.Contains(msg, "go.mod file not found"),
+		strings.Contains(msg, "matched no packages"):
+		return fmt.Errorf("%w: %w", ErrNoPackages, err)
+	default:
+		return fmt.Errorf("%w: %w", ErrPackageLoadFailed, err)
+	}
+}
+
+// workspacePatterns は loadDir に go.work があれば各 workspace モジュールごとの
+// "./<rel>/..." パターン列を返す。無ければ ["./..."] を返す。
+//
+// "./..." はネストした別モジュール（go.mod を持つサブディレクトリ）の境界で止まり
+// 中の別モジュールを列挙しないため、workspace（例: Kubernetes の staging/src/k8s.io/*）
+// では取りこぼしが出る。go list -m でモジュールディレクトリを列挙して補う。
+// 列挙に失敗したら ["./..."] にフォールバックする（最低限ルートモジュールは解析する）。
+func workspacePatterns(ctx context.Context, loadDir string) []string {
+	fallback := []string{"./..."}
+	if _, err := os.Stat(filepath.Join(loadDir, "go.work")); err != nil {
+		return fallback
+	}
+
+	cmd := exec.CommandContext(ctx, "go", "list", "-m", "-f", "{{.Dir}}")
+	cmd.Dir = loadDir
+	cmd.Env = analyzerEnv()
+	out, err := cmd.Output()
+	if err != nil {
+		return fallback
+	}
+
+	var patterns []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		dir := strings.TrimSpace(line)
+		if dir == "" {
+			continue
+		}
+		rel, err := filepath.Rel(loadDir, dir)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue // workspace 外（loadDir の外）のモジュールは対象外
+		}
+		if rel == "." {
+			patterns = append(patterns, "./...")
+		} else {
+			patterns = append(patterns, "./"+filepath.ToSlash(rel)+"/...")
+		}
+	}
+	if len(patterns) == 0 {
+		return fallback
+	}
+	return patterns
+}
+
 // FastLoad はrootDir配下の全Goパッケージを型チェックなしで高速ロードする。
 // 変更パッケージの特定と近傍パッケージの計算にのみ使う。
 func (l *GoPackageLoader) FastLoad(ctx context.Context, rootDir string) ([]*packages.Package, error) {
@@ -70,12 +164,12 @@ func (l *GoPackageLoader) FastLoad(ctx context.Context, rootDir string) ([]*pack
 		Dir:     rootDir,
 		Context: ctx,
 		Tests:   false,
-		Env:     append(os.Environ(), "GOWORK=off"),
+		Env:     analyzerEnv(),
 	}
 
-	pkgs, err := packages.Load(cfg, "./...")
+	pkgs, err := packages.Load(cfg, workspacePatterns(ctx, rootDir)...)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrNoPackages, err)
+		return nil, classifyLoadErr(err)
 	}
 
 	var usable int
@@ -91,7 +185,8 @@ func (l *GoPackageLoader) FastLoad(ctx context.Context, rootDir string) ([]*pack
 }
 
 // Load はpatterns で指定したパッケージを型情報付きでロードする。
-// GOWORK=offを強制してホスト環境のgo.workの影響を受けないようにする。
+// patterns はインポートパスのリストで、workspace では別モジュールのパッケージも
+// インポートパス指定でそのまま解決できる（analyzerEnv が go.work 自動探索を許すため）。
 func (l *GoPackageLoader) Load(ctx context.Context, rootDir string, patterns []string) (*LoadResult, error) {
 	if len(patterns) == 0 {
 		return &LoadResult{}, nil
@@ -102,12 +197,12 @@ func (l *GoPackageLoader) Load(ctx context.Context, rootDir string, patterns []s
 		Dir:     rootDir,
 		Context: ctx,
 		Tests:   false,
-		Env:     append(os.Environ(), "GOWORK=off"),
+		Env:     analyzerEnv(),
 	}
 
 	pkgs, err := packages.Load(cfg, patterns...)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrNoPackages, err)
+		return nil, classifyLoadErr(err)
 	}
 
 	// パッケージ個別のエラーを収集（型エラー等は致命扱いしない）

--- a/backend/internal/infra/analyzer/parser.go
+++ b/backend/internal/infra/analyzer/parser.go
@@ -273,7 +273,12 @@ func IdentifyChangedPackages(rootDir string, pkgs []*packages.Package, changed [
 // プロジェクト内パッケージのIDスライスを返す（重複なし・ソート済み）。
 // allPkgs は FastLoad で得たプロジェクト内パッケージのみを想定する。
 // 外部ライブラリは含まない。
-func FindNeighborhood(changedPkgs []string, allPkgs []*packages.Package, maxDepth int) []string {
+//
+// maxPkgs は返すパッケージ数の上限（<=0 で無制限）。BFS は深さ順に展開するため、
+// 上限に達したら近いホップを優先的に残して打ち切る。変更パッケージ自体は上限を
+// 超えても必ず含める（Phase 2 のフルロード対象が爆発してメモリ枯渇するのを防ぐ。
+// k8s 等のハブパッケージを含む PR では 3 ホップで数千パッケージに膨らむため）。
+func FindNeighborhood(changedPkgs []string, allPkgs []*packages.Package, maxDepth, maxPkgs int) []string {
 	// プロジェクトパッケージIDセット
 	projectIDs := make(map[string]struct{}, len(allPkgs))
 	for _, pkg := range allPkgs {
@@ -315,14 +320,22 @@ func FindNeighborhood(changedPkgs []string, allPkgs []*packages.Package, maxDept
 		}
 	}
 
+	capped := func() bool { return maxPkgs > 0 && len(visited) >= maxPkgs }
+
 	for len(queue) > 0 {
 		cur := queue[0]
 		queue = queue[1:]
 		if cur.depth >= maxDepth {
 			continue
 		}
+		if capped() {
+			break // 近いホップから埋めているので、上限到達で打ち切る
+		}
 		neighbors := append(forward[cur.id], reverse[cur.id]...)
 		for _, nid := range neighbors {
+			if capped() {
+				break
+			}
 			if _, ok := visited[nid]; !ok {
 				visited[nid] = struct{}{}
 				queue = append(queue, entry{nid, cur.depth + 1})

--- a/backend/internal/infra/analyzer/parser_classify_test.go
+++ b/backend/internal/infra/analyzer/parser_classify_test.go
@@ -1,0 +1,84 @@
+package analyzer
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestClassifyLoadErr(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want error
+	}{
+		{
+			name: "toolchain DL 失敗",
+			in:   "err: exit status 1: stderr: go: download go1.99.0 for linux/amd64: toolchain not available",
+			want: ErrGoToolchainUnavailable,
+		},
+		{
+			name: "要求 Go バージョン超過",
+			in:   "err: exit status 1: stderr: go: go.mod requires go >= 1.26.0 (running go 1.25.9)",
+			want: ErrGoToolchainUnavailable,
+		},
+		{
+			name: "go.mod 不在（Go リポジトリではない）",
+			in:   "err: exit status 1: stderr: pattern ./...: directory prefix . does not contain main module or its selected dependencies",
+			want: ErrNoPackages,
+		},
+		{
+			name: "その他のロード失敗",
+			in:   "err: exit status 1: stderr: could not import example.com/dep (invalid package name)",
+			want: ErrPackageLoadFailed,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyLoadErr(errors.New(tc.in))
+			if !errors.Is(got, tc.want) {
+				t.Errorf("classifyLoadErr(%q) = %v; want errors.Is(_, %v)", tc.in, got, tc.want)
+			}
+			// 元のエラー文言が失われていないこと（デバッグ用に保持する）。
+			if !strings.Contains(got.Error(), tc.in) {
+				t.Errorf("classified error %q lost original message %q", got.Error(), tc.in)
+			}
+		})
+	}
+}
+
+func TestGoPackageLoader_FastLoad_Workspace(t *testing.T) {
+	// go.work で root と ./sub の2モジュールを束ねる。"./..." はモジュール境界で
+	// 止まるため、workspacePatterns が両モジュールを列挙できることを確認する。
+	dir := writeFixture(t, map[string]string{
+		"go.work": "go 1.21\n\nuse (\n\t.\n\t./sub\n)\n",
+		"go.mod":  "module example.com/wsfix\n\ngo 1.21\n",
+		"root.go": `package wsfix
+
+func Root() {}
+`,
+		"sub/go.mod": "module example.com/wsfix/sub\n\ngo 1.21\n",
+		"sub/sub.go": `package sub
+
+func Sub() {}
+`,
+	})
+
+	loader := NewGoPackageLoader()
+	pkgs, err := loader.FastLoad(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("FastLoad: %v", err)
+	}
+
+	pkgIDs := make(map[string]struct{})
+	for _, pkg := range pkgs {
+		pkgIDs[pkg.ID] = struct{}{}
+	}
+
+	for _, want := range []string{"example.com/wsfix", "example.com/wsfix/sub"} {
+		if _, ok := pkgIDs[want]; !ok {
+			t.Errorf("workspace module %q not found; got: %v", want, pkgIDs)
+		}
+	}
+}

--- a/backend/internal/infra/analyzer/parser_classify_test.go
+++ b/backend/internal/infra/analyzer/parser_classify_test.go
@@ -82,3 +82,53 @@ func Sub() {}
 		}
 	}
 }
+
+func TestFindNeighborhood_Cap(t *testing.T) {
+	// a → b → c → d の import チェーン。a 起点・深さ十分でも maxPkgs=2 で打ち切られ、
+	// 起点の a は必ず含まれることを確認する。
+	dir := writeFixture(t, map[string]string{
+		"go.mod": "module example.com/cap\n\ngo 1.21\n",
+		"pkg/a/a.go": `package a
+
+import "example.com/cap/pkg/b"
+
+func FA() { b.FB() }
+`,
+		"pkg/b/b.go": `package b
+
+import "example.com/cap/pkg/c"
+
+func FB() { c.FC() }
+`,
+		"pkg/c/c.go": `package c
+
+import "example.com/cap/pkg/d"
+
+func FC() { d.FD() }
+`,
+		"pkg/d/d.go": `package d
+
+func FD() {}
+`,
+	})
+
+	loader := NewGoPackageLoader()
+	pkgs, err := loader.FastLoad(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("FastLoad: %v", err)
+	}
+
+	got := FindNeighborhood([]string{"example.com/cap/pkg/a"}, pkgs, 5, 2)
+	if len(got) > 2 {
+		t.Errorf("neighborhood not capped: got %d (%v), want <= 2", len(got), got)
+	}
+	var hasA bool
+	for _, id := range got {
+		if id == "example.com/cap/pkg/a" {
+			hasA = true
+		}
+	}
+	if !hasA {
+		t.Errorf("changed package a missing from capped neighborhood: %v", got)
+	}
+}

--- a/backend/internal/infra/analyzer/parser_test.go
+++ b/backend/internal/infra/analyzer/parser_test.go
@@ -322,7 +322,7 @@ func FD() {}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := FindNeighborhood(tc.changedPkgs, fastPkgs, tc.maxDepth)
+			got := FindNeighborhood(tc.changedPkgs, fastPkgs, tc.maxDepth, 0)
 			gotSet := make(map[string]struct{}, len(got))
 			for _, id := range got {
 				gotSet[id] = struct{}{}

--- a/backend/internal/infra/analyzer/source_tree.go
+++ b/backend/internal/infra/analyzer/source_tree.go
@@ -15,6 +15,11 @@ import (
 	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
 )
 
+// defaultMaxNeighborhood は Phase 2 で型情報付きロードする近傍パッケージ数の上限。
+// これを超える近傍は近いホップ優先で打ち切る。k8s のようなハブパッケージを含む
+// 巨大リポジトリでフルロードがメモリ枯渇するのを防ぐためのガード。
+const defaultMaxNeighborhood = 500
+
 // PreparedSource はclone・ロード・変更パッケージ特定の結果をまとめたもの。
 type PreparedSource struct {
 	RepoRoot            string // リポジトリルート（GitHub API パスの基点）
@@ -110,11 +115,16 @@ func (s *SourceTree) PrepareAtSHA(ctx context.Context, pr domain.PRInfo, token, 
 		}, nil
 	}
 
-	// Phase 2: 変更パッケージとその近傍（defaultMaxDepth ホップ以内）のみを
-	// 型情報付きでロードする。外部ライブラリは型チェックの依存として読まれるが
-	// 返却パッケージには含まれない。
-	neighborhood := FindNeighborhood(changedPkgs, fastPkgs, defaultMaxDepth)
-	log.Printf("analyzer: neighborhood(%d pkgs): %v", len(neighborhood), neighborhood)
+	// Phase 2: 変更パッケージとその近傍（defaultMaxDepth ホップ以内・最大
+	// defaultMaxNeighborhood 件）のみを型情報付きでロードする。外部ライブラリは
+	// 型チェックの依存として読まれるが返却パッケージには含まれない。
+	// 件数を上限で抑えるのは、ハブパッケージを含む PR（k8s 等）で近傍が数千件に
+	// 膨らみ、フルロード時にメモリ枯渇（OOM）するのを防ぐため。
+	neighborhood := FindNeighborhood(changedPkgs, fastPkgs, defaultMaxDepth, defaultMaxNeighborhood)
+	if len(neighborhood) >= defaultMaxNeighborhood {
+		log.Printf("analyzer: neighborhood capped at %d pkgs (changed=%d) — graph may be partial", defaultMaxNeighborhood, len(changedPkgs))
+	}
+	log.Printf("analyzer: neighborhood(%d pkgs)", len(neighborhood))
 
 	t1 := time.Now()
 	result, err := s.Loader.Load(ctx, loadDir, neighborhood)

--- a/compose.yml
+++ b/compose.yml
@@ -17,6 +17,12 @@ services:
       - "8080"
     env_file:
       - .env
+    environment:
+      # 大規模リポジトリ解析時のメモリ枯渇でホストごと落とさないためのソフト上限。
+      # 近傍パッケージ数の上限(defaultMaxNeighborhood)が主たる対策で、これは保険。
+      GOMEMLIMIT: "4GiB"
+    # OOM 時にホスト(WSL)を巻き込まずコンテナ単体で完結させるためのハード上限。
+    mem_limit: 5g
     volumes:
       - ./data:/app/data
     develop:

--- a/frontend/src/pages/Analysis.tsx
+++ b/frontend/src/pages/Analysis.tsx
@@ -33,8 +33,17 @@ function stepStatuses(jobStatus: string | undefined, phase: JobPhase | undefined
   })
 }
 
-function isNoPackagesError(msg: string | undefined) {
-  return msg?.includes('no Go packages found') || msg?.includes('ErrNoPackages')
+// errorMessage はバックエンドのエラー文字列を原因別のユーザー向け文言に変換する。
+// analyzer の sentinel error テキストに対応する（backend/internal/infra/analyzer/parser.go）。
+// 「ロード失敗」を一律「Go リポジトリではない」に丸めず、toolchain 起因と区別する。
+function errorMessage(msg: string | undefined): string {
+  if (msg?.includes('required Go toolchain unavailable')) {
+    return 'このリポジトリが要求する Go のバージョンを解析環境が用意できませんでした。少し時間をおいて再試行してください。'
+  }
+  if (msg?.includes('no Go packages found') || msg?.includes('ErrNoPackages')) {
+    return 'Go コードを含む PR ではありません。Go リポジトリの PR URL を指定してください。'
+  }
+  return msg ?? '解析中に予期しないエラーが発生しました。'
 }
 
 export default function Analysis() {
@@ -51,7 +60,6 @@ export default function Analysis() {
   }
 
   if (job.status === 'error') {
-    const isNonGo = isNoPackagesError(job.error)
     return (
       <div className="flex min-h-svh items-center justify-center bg-[#fafaf9]">
         <Card className="w-full max-w-md border-red-200">
@@ -60,11 +68,7 @@ export default function Analysis() {
               <ErrorIcon />
               <span>解析に失敗しました</span>
             </div>
-            <p className="text-sm text-stone-600">
-              {isNonGo
-                ? 'Go コードを含む PR ではありません。Go リポジトリの PR URL を指定してください。'
-                : job.error}
-            </p>
+            <p className="text-sm text-stone-600">{errorMessage(job.error)}</p>
             <Button asChild variant="outline" size="sm" className="mt-2">
               <Link to="/">別の PR を試す</Link>
             </Button>


### PR DESCRIPTION
## 概要

#76 を修正する。Kubernetes のような **Go workspace 構成 / 新しい Go バージョンを要求するリポジトリ** の解析が「Go コードを含む PR ではありません」と誤判定される問題を解消する。あわせて、調査の過程で判明した巨大リポジトリの OOM を暫定ガードで防ぐ。

Closes #76

## 変更内容

- **toolchain 自動取得**: `GOTOOLCHAIN=auto` を明示し、ベースイメージの `GOTOOLCHAIN=local` を上書き。リポジトリの go.mod が要求する新しい Go を必要時に自動 DL する（`parser.go` `analyzerEnv`）。Go ベースイメージも 1.26 に更新。
- **go.work 対応**: 一律 `GOWORK=off` の強制をやめ、clone した一時ディレクトリ内の go.work 解決を go の自動探索に委ねる。`go list -m` で workspace の各モジュール（k8s の `staging/src/k8s.io/*` 等）を列挙し、`./...` では取りこぼす別モジュールも解析対象に含める（`workspacePatterns`）。
- **エラー分類**: ロード失敗を `ErrNoPackages`（Go パッケージ皆無）/ `ErrGoToolchainUnavailable`（toolchain 入手失敗）/ `ErrPackageLoadFailed`（依存・vendoring 不整合）に分離。frontend は原因に応じた文言を出し分け、有効な Go リポジトリのロード失敗を「Go リポジトリではない」と丸めない（`classifyLoadErr` / `Analysis.tsx`）。
- **OOM 暫定ガード**: 近傍パッケージ数に上限を設け（`defaultMaxNeighborhood`）、ハブパッケージを含む PR でフルロードがメモリ枯渇するのを防ぐ。

## 備考: 速度・メモリは別 issue で継続議論

巨大リポジトリ（k8s 等）の **解析が遅い / メモリが厳しい** という根本問題は本 PR のスコープ外とし、別 issue #79 に切り出した。本 PR の OOM ガードはあくまで暫定。具体的な解決策はそちらで議論する。

## Test plan

- [ ] backend: `docker compose run --build --rm backend go test ./...` が通る
- [ ] backend lint: `docker run --rm -v $(pwd)/backend:/app -w /app golang:1.26 sh -c 'gofmt -l . && go vet ./...'` がクリーン
- [ ] frontend: `docker compose run --rm frontend sh -c 'npm run lint && npx tsc -b'` が通る
- [ ] 実機確認（UI 変更あり / `Analysis.tsx`）: 解析失敗時のエラー文言が原因別に出し分けられること
  - [ ] toolchain 入手失敗時の文言
  - [ ] 依存解決失敗時の文言
  - [ ] 真に Go パッケージが無い PR で従来どおり「Go コードを含む PR ではありません」
- [ ] k8s PR (kubernetes/kubernetes#139240) が誤判定されず解析に入ること（速度・OOM は別 issue 管理）
