### PR TITLE
perf: 解析スループット改善（ワーカープール化・ジョブtimeout・DB競合回避・キャッシュSHA検証）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,5 +8,14 @@ PORT=8080
 SESSION_SECRET=change_this_to_random_string
 DB_PATH=/app/data/reviewarena.db
 
+# 解析ジョブ（任意・省略時はデフォルト値）
+# JOB_WORKERS: 同時に走らせる解析ワーカー数（省略時 = min(CPU数, 4)）。
+#   1ジョブは型チェック＋SSA/CHA で CPU/メモリを多く使うため、GOMEMLIMIT/mem_limit と合わせて調整する。
+# JOB_TIMEOUT_SECONDS: 1ジョブの解析時間上限（省略時 120）。巨大リポジトリの暴走対策。
+# JOB_QUEUE_BUFFER: ジョブキューのバッファ長（省略時 32）。
+# JOB_WORKERS=4
+# JOB_TIMEOUT_SECONDS=120
+# JOB_QUEUE_BUFFER=32
+
 # nginx 経由で同一オリジンになるため VITE_API_BASE_URL は不要
 # フロントエンドからは /api/* を直接叩く

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime"
 	"strconv"
 	"syscall"
 	"time"
@@ -58,9 +59,22 @@ func main() {
 
 	queueBuf := envIntOr("JOB_QUEUE_BUFFER", 32)
 	queue := job.NewQueue(queueBuf)
-	worker := job.NewWorker(queue, jobRepo, analysisRepo, prRepo, sourceTree, cgBuilder, clusterer)
 
-	analyzeUC := usecase.NewAnalyzePRUseCase(analysisRepo, jobRepo, queue)
+	// 1ジョブの解析時間上限。暴走解析がワーカーを占有し続けるのを防ぐ安全弁。
+	jobTimeout := time.Duration(envIntOr("JOB_TIMEOUT_SECONDS", 120)) * time.Second
+	worker := job.NewWorker(queue, jobRepo, analysisRepo, prRepo, sourceTree, cgBuilder, clusterer,
+		job.WithJobTimeout(jobTimeout))
+
+	// 同時に走らせる解析ワーカー数。直列実行だと1ジョブが詰まると後続（他ユーザー）が
+	// 全員待たされるためプール化する。1ジョブは base/head を内部で並列構築し CPU/メモリを
+	// 多く使う（型チェック＋SSA/CHA）ため、既定値は CPU 数と 4 の小さい方に抑える。
+	// メモリ枯渇を避けるには compose.yml の GOMEMLIMIT/mem_limit と合わせて調整すること。
+	workerCount := envIntOr("JOB_WORKERS", min(runtime.NumCPU(), 4))
+	if workerCount < 1 {
+		workerCount = 1
+	}
+
+	analyzeUC := usecase.NewAnalyzePRUseCase(analysisRepo, jobRepo, prRepo, queue)
 	getUC := usecase.NewGetAnalysisUseCase(analysisRepo, jobRepo)
 
 	oauth := githubinfra.NewOAuthConfig(clientID, clientSecret, callbackURL)
@@ -75,9 +89,12 @@ func main() {
 
 	eg, egCtx := errgroup.WithContext(ctx)
 
-	eg.Go(func() error {
-		return worker.Run(egCtx)
-	})
+	log.Printf("startup: launching %d analysis worker(s) (job timeout %s)", workerCount, jobTimeout)
+	for i := 0; i < workerCount; i++ {
+		eg.Go(func() error {
+			return worker.Run(egCtx)
+		})
+	}
 
 	eg.Go(func() error {
 		if err := router.Start(":" + port); err != nil && err != http.ErrServerClosed {

--- a/backend/internal/infra/job/worker.go
+++ b/backend/internal/infra/job/worker.go
@@ -126,7 +126,11 @@ func (w *Worker) process(ctx context.Context, item Item) {
 			err = fmt.Errorf("解析がタイムアウトしました（%s）。対象リポジトリ／PR が大きすぎる可能性があります", timeout)
 		}
 		log.Printf("worker: job %s failed: %v", jobID, err)
-		_ = w.jobs.UpdateStatus(context.WithoutCancel(ctx), jobID, domain.JobStatusError, err.Error())
+		// 親 ctx のキャンセル／タイムアウトとは切り離しつつ、DB が詰まっても
+		// シャットダウン時にワーカーが永久ブロックしないよう短いタイムアウトを付ける。
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		_ = w.jobs.UpdateStatus(cleanupCtx, jobID, domain.JobStatusError, err.Error())
 	}
 	// setPhase はフロントの進捗表示用にジョブの現在フェーズを更新する。
 	// 進捗表示は付随情報なので、失敗してもジョブ自体は止めずログのみ残す。

--- a/backend/internal/infra/job/worker.go
+++ b/backend/internal/infra/job/worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"log"
 	"sync"
@@ -30,7 +31,14 @@ type sourceTreePreparer interface {
 	PrepareAtSHA(ctx context.Context, pr domain.PRInfo, token, sha string, changed []domain.ChangedFile) (*analyzer.PreparedSource, error)
 }
 
+// defaultJobTimeout は1ジョブの解析にかける時間の上限のデフォルト値。
+// 巨大リポジトリ（k8s 等）の解析が暴走してワーカーを無限に占有し、
+// 後続ジョブ（＝他ユーザー）を巻き添えにするのを防ぐ安全弁。
+const defaultJobTimeout = 120 * time.Second
+
 // Worker はキューからジョブを受け取り解析パイプラインを実行する。
+// Run は複数 goroutine から同時に呼び出して構わない（フィールドは不変、
+// ジョブ処理は注入された依存のみを使い受信側の可変状態を持たない）。
 type Worker struct {
 	queue      *Queue
 	jobs       jobStore
@@ -41,6 +49,20 @@ type Worker struct {
 	clusterer  cluster.Clusterer
 	now        func() time.Time
 	newID      func() string
+	jobTimeout time.Duration
+}
+
+// Option は Worker の任意設定を変更する関数オプション。
+type Option func(*Worker)
+
+// WithJobTimeout は1ジョブあたりの処理時間上限を設定する。
+// d <= 0 のときはデフォルト値を使う。
+func WithJobTimeout(d time.Duration) Option {
+	return func(w *Worker) {
+		if d > 0 {
+			w.jobTimeout = d
+		}
+	}
 }
 
 // NewWorker は Worker を返す。
@@ -52,8 +74,9 @@ func NewWorker(
 	sourceTree sourceTreePreparer,
 	cgBuilder analyzer.CallGraphBuilder,
 	clusterer cluster.Clusterer,
+	opts ...Option,
 ) *Worker {
-	return &Worker{
+	w := &Worker{
 		queue:      queue,
 		jobs:       jobs,
 		analyses:   analyses,
@@ -63,7 +86,12 @@ func NewWorker(
 		clusterer:  clusterer,
 		now:        time.Now,
 		newID:      workerRandomID,
+		jobTimeout: defaultJobTimeout,
 	}
+	for _, opt := range opts {
+		opt(w)
+	}
+	return w
 }
 
 // Run はジョブキューを読み込み、ctx がキャンセルされるかキューが閉じるまでブロックする。
@@ -83,9 +111,22 @@ func (w *Worker) Run(ctx context.Context) error {
 
 func (w *Worker) process(ctx context.Context, item Item) {
 	jobID := item.JobID
+
+	// ジョブ単位のタイムアウト。暴走解析が1本のワーカーを占有し続けるのを防ぐ。
+	timeout := w.jobTimeout
+	if timeout <= 0 {
+		timeout = defaultJobTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
 	fail := func(err error) {
+		// タイムアウト由来の失敗は原因が分かる文言に置き換える（巨大リポジトリの可能性）。
+		if errors.Is(err, context.DeadlineExceeded) || ctx.Err() == context.DeadlineExceeded {
+			err = fmt.Errorf("解析がタイムアウトしました（%s）。対象リポジトリ／PR が大きすぎる可能性があります", timeout)
+		}
 		log.Printf("worker: job %s failed: %v", jobID, err)
-		_ = w.jobs.UpdateStatus(ctx, jobID, domain.JobStatusError, err.Error())
+		_ = w.jobs.UpdateStatus(context.WithoutCancel(ctx), jobID, domain.JobStatusError, err.Error())
 	}
 	// setPhase はフロントの進捗表示用にジョブの現在フェーズを更新する。
 	// 進捗表示は付随情報なので、失敗してもジョブ自体は止めずログのみ残す。

--- a/backend/internal/infra/job/worker_test.go
+++ b/backend/internal/infra/job/worker_test.go
@@ -3,6 +3,7 @@ package job
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -343,6 +344,67 @@ func TestWorker_ContextCancel_StopsLoop(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Error("Run did not stop after context cancel")
+	}
+}
+
+// blockingSourceTree は ctx がキャンセル/タイムアウトされるまで Prepare をブロックする。
+type blockingSourceTree struct{}
+
+func (s *blockingSourceTree) Prepare(ctx context.Context, _ domain.PRInfo, _ string, _ []domain.ChangedFile) (*analyzer.PreparedSource, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (s *blockingSourceTree) PrepareAtSHA(ctx context.Context, _ domain.PRInfo, _, _ string, _ []domain.ChangedFile) (*analyzer.PreparedSource, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func TestWorker_JobTimeout_MarksError(t *testing.T) {
+	prInfo := &domain.PRInfo{Owner: "o", Repo: "r", Number: 1, HeadSHA: "h", BaseSHA: "b"}
+	jobs := newFakeJobStore()
+	jobs.jobs["job-t"] = &domain.Job{
+		ID:     "job-t",
+		Status: domain.JobStatusPending,
+		PR:     domain.PRInfo{Owner: "o", Repo: "r", Number: 1},
+	}
+	analyses := &fakeAnalysisRepo{}
+
+	q := NewQueue(1)
+	w := NewWorker(q, jobs, analyses,
+		&fakePRRepo{prInfo: prInfo, changed: []domain.ChangedFile{}},
+		&blockingSourceTree{},
+		&fakeCGBuilder{graph: &domain.Graph{}},
+		&fakeClusterer{result: &domain.ClusterResult{}},
+		WithJobTimeout(50*time.Millisecond),
+	)
+	w.now = func() time.Time { return time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC) }
+	w.newID = func() string { return fixedID }
+
+	done := make(chan struct{})
+	go func() {
+		w.process(context.Background(), Item{JobID: "job-t", Token: "tok"})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("process did not return after job timeout")
+	}
+
+	j := jobs.jobs["job-t"]
+	if j.Status != domain.JobStatusError {
+		t.Errorf("expected error status, got %s", j.Status)
+	}
+	var gotMsg string
+	for _, c := range jobs.statusCalls {
+		if c.status == domain.JobStatusError {
+			gotMsg = c.errMsg
+		}
+	}
+	if !strings.Contains(gotMsg, "タイムアウト") {
+		t.Errorf("expected timeout message, got %q", gotMsg)
 	}
 }
 

--- a/backend/internal/infra/store/db.go
+++ b/backend/internal/infra/store/db.go
@@ -22,6 +22,15 @@ func Open(dsn string) (*sql.DB, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("ping sqlite: %w", err)
 	}
+
+	// 解析ワーカーをプール化（複数並列実行）すると、複数 goroutine が同じ DB へ
+	// 同時書き込みする。SQLite はライタが1つに限られ、コネクションを複数開くと
+	// "database is locked" (SQLITE_BUSY) が発生し得る。コネクションを1本に固定して
+	// 全 SQL を直列化することで競合を根本的に避ける。DB アクセスは解析本体（秒オーダ）
+	// に比べ極小・低頻度なので直列化のコストは無視できる。
+	// 副次効果として、modernc.org/sqlite の :memory: はコネクション単位で別 DB に
+	// なるため、テストの :memory: 利用も1本固定で安定する。
+	db.SetMaxOpenConns(1)
 	if _, err := db.Exec(schema); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("apply schema: %w", err)

--- a/backend/internal/usecase/analyze_pr.go
+++ b/backend/internal/usecase/analyze_pr.go
@@ -19,16 +19,18 @@ type JobEnqueuer interface {
 type AnalyzePRUseCase struct {
 	analyses domain.AnalysisRepository
 	jobs     domain.JobRepository
+	prRepo   domain.PRRepository
 	queue    JobEnqueuer
 	now      func() time.Time
 	newID    func() string
 }
 
 // NewAnalyzePRUseCase は AnalyzePRUseCase を返す。
-func NewAnalyzePRUseCase(analyses domain.AnalysisRepository, jobs domain.JobRepository, queue JobEnqueuer) *AnalyzePRUseCase {
+func NewAnalyzePRUseCase(analyses domain.AnalysisRepository, jobs domain.JobRepository, prRepo domain.PRRepository, queue JobEnqueuer) *AnalyzePRUseCase {
 	return &AnalyzePRUseCase{
 		analyses: analyses,
 		jobs:     jobs,
+		prRepo:   prRepo,
 		queue:    queue,
 		now:      time.Now,
 		newID:    randomID,
@@ -36,8 +38,18 @@ func NewAnalyzePRUseCase(analyses domain.AnalysisRepository, jobs domain.JobRepo
 }
 
 // Execute はPR解析ジョブを開始し、JobIDを返す。
-// キャッシュ (同一 PR の既存解析) があれば done ジョブを即返し、enqueue しない。
+// キャッシュ (同一 PR かつ head/base SHA まで一致する既存解析) があれば done ジョブを
+// 即返し、enqueue しない。SHA を照合するのは、新しいコミットが積まれた PR に対して
+// 古い SHA の解析結果を返してしまわないようにするため（FindByPR は PR 番号で最新行を
+// 引くだけで SHA を見ないため、ここで弾く）。
 func (uc *AnalyzePRUseCase) Execute(ctx context.Context, token string, pr domain.PRInfo) (domain.JobID, error) {
+	// 現在の head/base SHA を解決してキャッシュキーに使う。
+	resolved, err := uc.prRepo.GetPR(ctx, token, pr.Owner, pr.Repo, pr.Number)
+	if err != nil {
+		return "", fmt.Errorf("resolve PR: %w", err)
+	}
+	pr = *resolved
+
 	cached, err := uc.analyses.FindByPR(ctx, pr)
 	if err != nil {
 		return "", fmt.Errorf("find cached analysis: %w", err)
@@ -46,7 +58,8 @@ func (uc *AnalyzePRUseCase) Execute(ctx context.Context, token string, pr domain
 	now := uc.now().UTC()
 	jobID := domain.JobID(uc.newID())
 
-	if cached != nil && cached.ChangedFiles != nil {
+	if cached != nil && cached.ChangedFiles != nil &&
+		cached.PR.HeadSHA == pr.HeadSHA && cached.PR.BaseSHA == pr.BaseSHA {
 		j := &domain.Job{
 			ID:         jobID,
 			AnalysisID: cached.ID,

--- a/backend/internal/usecase/analyze_pr_test.go
+++ b/backend/internal/usecase/analyze_pr_test.go
@@ -36,6 +36,26 @@ func (r *fakeAnalysisRepo) FindByPR(_ context.Context, _ domain.PRInfo) (*domain
 	return r.byPR, r.err
 }
 
+type fakePRRepo struct {
+	pr  *domain.PRInfo
+	err error
+}
+
+func (r *fakePRRepo) GetPR(_ context.Context, _, _, _ string, _ int) (*domain.PRInfo, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.pr, nil
+}
+
+func (r *fakePRRepo) ListChangedGoFiles(_ context.Context, _, _, _ string, _ int) ([]domain.ChangedFile, error) {
+	return nil, r.err
+}
+
+func (r *fakePRRepo) GetFileContent(_ context.Context, _, _, _, _, _ string) ([]byte, error) {
+	return nil, r.err
+}
+
 type fakeJobRepo struct {
 	saved []*domain.Job
 	err   error
@@ -82,8 +102,9 @@ func TestAnalyzePR_CacheMiss_Enqueue(t *testing.T) {
 	analyses := &fakeAnalysisRepo{byPR: nil}
 	jobs := &fakeJobRepo{}
 	enqueuer := &fakeEnqueuer{}
+	prRepo := &fakePRRepo{pr: &domain.PRInfo{Owner: "o", Repo: "r", Number: 1, HeadSHA: "h1", BaseSHA: "b1"}}
 
-	uc := NewAnalyzePRUseCase(analyses, jobs, enqueuer)
+	uc := NewAnalyzePRUseCase(analyses, jobs, prRepo, enqueuer)
 	pr := domain.PRInfo{Owner: "o", Repo: "r", Number: 1}
 
 	jobID, err := uc.Execute(context.Background(), "token-xxx", pr)
@@ -110,14 +131,15 @@ func TestAnalyzePR_CacheMiss_Enqueue(t *testing.T) {
 func TestAnalyzePR_CacheHit_NoEnqueue(t *testing.T) {
 	cachedAnalysis := &domain.Analysis{
 		ID:           "cached-analysis",
-		PR:           domain.PRInfo{Owner: "o", Repo: "r", Number: 1},
+		PR:           domain.PRInfo{Owner: "o", Repo: "r", Number: 1, HeadSHA: "h1", BaseSHA: "b1"},
 		ChangedFiles: []domain.DiffFile{},
 	}
 	analyses := &fakeAnalysisRepo{byPR: cachedAnalysis}
 	jobs := &fakeJobRepo{}
 	enqueuer := &fakeEnqueuer{}
+	prRepo := &fakePRRepo{pr: &domain.PRInfo{Owner: "o", Repo: "r", Number: 1, HeadSHA: "h1", BaseSHA: "b1"}}
 
-	uc := NewAnalyzePRUseCase(analyses, jobs, enqueuer)
+	uc := NewAnalyzePRUseCase(analyses, jobs, prRepo, enqueuer)
 	pr := domain.PRInfo{Owner: "o", Repo: "r", Number: 1}
 
 	jobID, err := uc.Execute(context.Background(), "token-xxx", pr)
@@ -141,13 +163,42 @@ func TestAnalyzePR_CacheHit_NoEnqueue(t *testing.T) {
 	}
 }
 
+// 新しいコミットで head SHA が変わった PR は、PR 番号が一致する古い解析が
+// キャッシュにあっても再解析（enqueue）されること。
+func TestAnalyzePR_StaleSHA_Reanalyze(t *testing.T) {
+	cachedAnalysis := &domain.Analysis{
+		ID:           "cached-analysis",
+		PR:           domain.PRInfo{Owner: "o", Repo: "r", Number: 1, HeadSHA: "old", BaseSHA: "b1"},
+		ChangedFiles: []domain.DiffFile{},
+	}
+	analyses := &fakeAnalysisRepo{byPR: cachedAnalysis}
+	jobs := &fakeJobRepo{}
+	enqueuer := &fakeEnqueuer{}
+	prRepo := &fakePRRepo{pr: &domain.PRInfo{Owner: "o", Repo: "r", Number: 1, HeadSHA: "new", BaseSHA: "b1"}}
+
+	uc := NewAnalyzePRUseCase(analyses, jobs, prRepo, enqueuer)
+	pr := domain.PRInfo{Owner: "o", Repo: "r", Number: 1}
+
+	_, err := uc.Execute(context.Background(), "token-xxx", pr)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(jobs.saved) != 1 || jobs.saved[0].Status != domain.JobStatusPending {
+		t.Fatalf("expected 1 pending job, got %+v", jobs.saved)
+	}
+	if len(enqueuer.calls) != 1 {
+		t.Errorf("expected 1 enqueue call (re-analyze), got %d", len(enqueuer.calls))
+	}
+}
+
 func TestAnalyzePR_RepoError_Propagated(t *testing.T) {
 	sentinel := errors.New("db down")
 	analyses := &fakeAnalysisRepo{err: sentinel}
 	jobs := &fakeJobRepo{}
 	enqueuer := &fakeEnqueuer{}
+	prRepo := &fakePRRepo{pr: &domain.PRInfo{Owner: "o", Repo: "r", Number: 1, HeadSHA: "h1", BaseSHA: "b1"}}
 
-	uc := NewAnalyzePRUseCase(analyses, jobs, enqueuer)
+	uc := NewAnalyzePRUseCase(analyses, jobs, prRepo, enqueuer)
 	_, err := uc.Execute(context.Background(), "t", domain.PRInfo{Owner: "o", Repo: "r", Number: 1})
 	if !errors.Is(err, sentinel) {
 		t.Errorf("expected sentinel error, got %v", err)
@@ -158,8 +209,9 @@ func TestAnalyzePR_IDsAreUnique(t *testing.T) {
 	analyses := &fakeAnalysisRepo{}
 	jobs := &fakeJobRepo{}
 	enqueuer := &fakeEnqueuer{}
+	prRepo := &fakePRRepo{pr: &domain.PRInfo{Owner: "o", Repo: "r", Number: 1, HeadSHA: "h1", BaseSHA: "b1"}}
 
-	uc := NewAnalyzePRUseCase(analyses, jobs, enqueuer)
+	uc := NewAnalyzePRUseCase(analyses, jobs, prRepo, enqueuer)
 	uc.now = func() time.Time { return time.Now() }
 
 	pr := domain.PRInfo{Owner: "o", Repo: "r", Number: 1}


### PR DESCRIPTION
## 概要

#79 の調査を踏まえ、「100人同時利用でも結果が現実的な時間で返る」ための **構成・信頼性まわり（A群）** を実装する。per-job のアルゴリズム最適化（Phase2 型チェック閉包の削減・SSA/CHA の近傍限定等）は別 issue に分割予定。

調査の要点（コードから導いた計算量・支配項）:
- 1ジョブの支配項は **Phase 2 の型チェック**（変更パッケージの推移依存閉包をソースから再型チェック）。近傍 500 件上限は要求パッケージを縛るが依存閉包 D を縛れない。
- だが「100同時/30-60s」を阻む最大要因は **構成**だった: ワーカーが1本のみで直列処理・**ジョブtimeout無し**・キャッシュは存在するが **SHA未検証で stale**。

## 変更内容

1. **fix: SQLite 単一コネクション化** (`store/db.go`)
   - `SetMaxOpenConns(1)` で全 SQL を直列化。複数ワーカーの `database is locked` を根本回避。`:memory:` テストの安定化も兼ねる。
2. **fix: ジョブ単位タイムアウト** (`job/worker.go`)
   - `WithJobTimeout`（既定 120s）を追加し `process` で ctx に被せる。暴走解析が1本のワーカーを占有し続けるのを防ぐ。超過時は原因の分かる文言で error に。
3. **perf: 解析ワーカーのプール化** (`cmd/server/main.go`)
   - `JOB_WORKERS` 本（既定 `min(CPU数, 4)`）を同一キューから並列実行。`JOB_TIMEOUT_SECONDS` も env 化。
4. **fix: 結果キャッシュの SHA 検証** (`usecase/analyze_pr.go`)
   - `FindByPR` は PR 番号で最新行を引くだけで SHA を見ず、新コミットが積まれた PR に **古い解析結果を永久に返していた**。`Execute` で現在の head/base SHA を解決し、SHA 一致時のみキャッシュヒットさせる。

## 補足（メモリとの兼ね合い）

- 1ジョブは base/head を内部で並列構築し CPU/メモリを多く使う。`JOB_WORKERS` を増やす際は `compose.yml` の `GOMEMLIMIT`/`mem_limit` と合わせて調整すること（既定値は控えめにしてある）。

## Test plan

- [x] `gofmt -l .` クリーン / `go vet ./...` パス
- [x] `docker compose run --build --rm backend go test ./...` 全パス（タイムアウト・stale SHA 再解析の新規テスト含む）
- [ ] **実機**: dev server を `JOB_WORKERS=4` で起動し、複数 PR を同時投入 → 並列に処理が進む（直列に待たされない）ことをログで確認
- [ ] **実機**: 同一 PR を解析 → 2回目がキャッシュ即返しになることを確認
- [ ] **実機**: 解析済み PR に新コミットを積んで再解析 → 古い結果ではなく再解析されることを確認（stale 修正の検証）
- [ ] **実機**: 巨大リポジトリ（k8s 等）投入 → タイムアウトで error になり、後続ジョブが処理されることを確認

## 関連

- #79