### PR TITLE
feat: リポジトリ全体サイズの上限ガードを追加 (#83)

### DIFF
--- a/backend/internal/infra/analyzer/parser.go
+++ b/backend/internal/infra/analyzer/parser.go
@@ -28,6 +28,18 @@ var ErrGoToolchainUnavailable = errors.New("analyzer: required Go toolchain unav
 // （依存解決・vendoring 不整合など）。「Go パッケージ皆無」とは区別する。
 var ErrPackageLoadFailed = errors.New("analyzer: failed to load Go packages")
 
+// ErrRepositoryTooLarge はリポジトリ全体のパッケージ数が maxFastLoadPackages を超え、
+// 解析対象外として明示的に reject するときの sentinel error。
+// PR の変更規模ではなくリポジトリ全体サイズで判定するため、巨大リポジトリ上の
+// 小さな PR は弾かれず、コアバリュー（大きな PR の分割）には影響しない。
+var ErrRepositoryTooLarge = errors.New("analyzer: repository is too large to analyze")
+
+// maxFastLoadPackages は FastLoad で得たプロジェクト全体のパッケージ数の上限。
+// これを超えるリポジトリは Phase 2（型情報付きロード）に進む前に reject する。
+// k8s 規模のリポジトリで型ロードやジョブタイムアウト（120s）が無言で発火するのを防ぎ、
+// ユーザーに「大規模リポジトリは未対応」と分かりやすく返すための入口側ガード。
+const maxFastLoadPackages = 1500
+
 // loadMode は callgraph (#5) と diff→AST マップ (#6) で必要なフラグを全て含む。
 const loadMode = packages.NeedName |
 	packages.NeedFiles |

--- a/backend/internal/infra/analyzer/source_tree.go
+++ b/backend/internal/infra/analyzer/source_tree.go
@@ -89,6 +89,14 @@ func (s *SourceTree) PrepareAtSHA(ctx context.Context, pr domain.PRInfo, token, 
 	}
 	log.Printf("analyzer: phase1 FastLoad(%d pkgs) took %s", len(fastPkgs), time.Since(t0))
 
+	// リポジトリ全体のパッケージ数が上限を超えるなら、Phase 2（型情報付きロード）に
+	// 進む前に reject する。型ロードやジョブタイムアウトが無言で発火するのを防ぎ、
+	// ユーザーに「大規模リポジトリは未対応」と明示するための入口側ガード。
+	if len(fastPkgs) > maxFastLoadPackages {
+		_ = cloned.Cleanup()
+		return nil, fmt.Errorf("%w: detected %d packages (limit %d)", ErrRepositoryTooLarge, len(fastPkgs), maxFastLoadPackages)
+	}
+
 	// GitHub API の changed ファイルパスはリポジトリルート相対なので clonedRoot を基点にする。
 	changedPkgs := IdentifyChangedPackages(clonedRoot, fastPkgs, changed)
 	log.Printf("analyzer: changed packages: %v", changedPkgs)

--- a/backend/internal/infra/analyzer/source_tree_test.go
+++ b/backend/internal/infra/analyzer/source_tree_test.go
@@ -47,6 +47,26 @@ func (e *errorLoader) Load(_ context.Context, _ string, _ []string) (*LoadResult
 	return nil, ErrNoPackages
 }
 
+// countingLoader は FastLoad で指定個数の空パッケージを返し、Load 呼び出し有無を追跡する
+// テスト用 Loader。リポジトリサイズ上限ガードの検証に使う。
+type countingLoader struct {
+	fastLoadCount int
+	loadCalled    bool
+}
+
+func (l *countingLoader) FastLoad(_ context.Context, _ string) ([]*packages.Package, error) {
+	pkgs := make([]*packages.Package, l.fastLoadCount)
+	for i := range pkgs {
+		pkgs[i] = &packages.Package{}
+	}
+	return pkgs, nil
+}
+
+func (l *countingLoader) Load(_ context.Context, _ string, _ []string) (*LoadResult, error) {
+	l.loadCalled = true
+	return &LoadResult{}, nil
+}
+
 func TestSourceTree_Prepare_Success(t *testing.T) {
 	// fixture: 2パッケージ構成のGoモジュール
 	dir := writeFixture(t, map[string]string{
@@ -179,5 +199,39 @@ func TestSourceTree_Prepare_LoaderFailure_CleansUp(t *testing.T) {
 	// 実際のdirがまだ存在することを確認（fakeなので消されない）
 	if _, err := os.Stat(dir); err != nil {
 		t.Errorf("fixture dir should still exist: %v", err)
+	}
+}
+
+func TestSourceTree_Prepare_RepositoryTooLarge_Rejects(t *testing.T) {
+	// go.mod を持つfixture（findGoModRootを通すため）。パッケージの中身は問わない。
+	dir := writeFixture(t, map[string]string{
+		"go.mod": "module example.com/fixture\n\ngo 1.21\n",
+	})
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fc := &fakeCloner{fixtureDir: resolvedDir}
+	cl := &countingLoader{fastLoadCount: maxFastLoadPackages + 1}
+	st := NewSourceTree(fc, cl)
+
+	pr := domain.PRInfo{Owner: "o", Repo: "r", HeadSHA: "sha"}
+	changed := []domain.ChangedFile{{Filename: "pkg/a/a.go", Status: "modified"}}
+
+	_, err = st.Prepare(context.Background(), pr, "", changed)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrRepositoryTooLarge) {
+		t.Errorf("expected ErrRepositoryTooLarge, got: %v", err)
+	}
+	// 上限超過時は Phase 2（型情報付きロード）へ進まないこと
+	if cl.loadCalled {
+		t.Error("Load should not be called when repository exceeds the package limit")
+	}
+	// reject 時も Cleanup が呼ばれ部分状態を残さないこと
+	if !fc.cleanupCalled {
+		t.Error("expected fakeCloner.Cleanup to be called on reject")
 	}
 }

--- a/backend/internal/infra/job/worker.go
+++ b/backend/internal/infra/job/worker.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"log"
 	"sync"
@@ -142,10 +141,6 @@ func (w *Worker) process(ctx context.Context, item Item) {
 		}
 	}()
 	if err != nil {
-		if errors.Is(err, analyzer.ErrRepositoryTooLarge) {
-			fail(errors.New("大規模リポジトリは未対応です（リポジトリ全体のパッケージ数が上限を超過）。より小規模な Go リポジトリの PR でお試しください。"))
-			return
-		}
 		fail(fmt.Errorf("build base/head graphs: %w", err))
 		return
 	}

--- a/backend/internal/infra/job/worker.go
+++ b/backend/internal/infra/job/worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"log"
 	"sync"
@@ -141,6 +142,10 @@ func (w *Worker) process(ctx context.Context, item Item) {
 		}
 	}()
 	if err != nil {
+		if errors.Is(err, analyzer.ErrRepositoryTooLarge) {
+			fail(errors.New("大規模リポジトリは未対応です（リポジトリ全体のパッケージ数が上限を超過）。より小規模な Go リポジトリの PR でお試しください。"))
+			return
+		}
 		fail(fmt.Errorf("build base/head graphs: %w", err))
 		return
 	}

--- a/frontend/src/pages/Analysis.tsx
+++ b/frontend/src/pages/Analysis.tsx
@@ -43,6 +43,9 @@ function errorMessage(msg: string | undefined): string {
   if (msg?.includes('no Go packages found') || msg?.includes('ErrNoPackages')) {
     return 'Go コードを含む PR ではありません。Go リポジトリの PR URL を指定してください。'
   }
+  if (msg?.includes('repository is too large to analyze')) {
+    return '大規模リポジトリは未対応です（リポジトリ全体のパッケージ数が上限を超過）。より小規模な Go リポジトリの PR でお試しください。'
+  }
   return msg ?? '解析中に予期しないエラーが発生しました。'
 }
 


### PR DESCRIPTION
## 概要
大規模リポジトリ（k8s 規模）の解析で、型ロードやジョブタイムアウト（120s）が無言で発火し原因不明のエラーになる問題に対し、**リポジトリ全体サイズ（FastLoad パッケージ数）で明示的に reject** する入口側ガードを追加する。

Closes #83

## 設計判断
判定は**リポジトリ全体サイズのみ**で行い、PR の変更規模（変更pkg数・ファイル数）にはペナルティを設けない。巨大リポジトリ上の小さな PR は弾かれず、「大きな PR を分割する」というコアバリューには影響しない。

#83 原案の以下は意図的に除外:
- 変更pkg > 50 で depth 縮退（大きな PR こそ対象なので矛盾）
- 変更ファイル > 300 で打ち切り
- 大repo時 defaultMaxDepth 3→2

## 変更点
- `parser.go`: `ErrRepositoryTooLarge` sentinel error と `maxFastLoadPackages = 1500` を追加
- `source_tree.go`: `PrepareAtSHA` の FastLoad 直後にガード。上限超過時は Phase 2 に進まず Cleanup して reject
- `worker.go`: `errors.Is` で判定し、日本語の分かりやすいメッセージを `Job.Error` に保存（→ `JobResponse.Error` 経由でフロントへ）
- `source_tree_test.go`: 上限超過 reject のテストを追加

## Test plan
- [x] `gofmt -l`: 差分なし
- [x] `go vet ./...`: エラーなし
- [x] `go test ./internal/infra/analyzer/... ./internal/infra/job/...`: pass（新テスト含む）
- [ ] フロント側で `status: error` 時にこのメッセージが画面表示されるか（別途 #76 のエラー分類表示と整合確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)