### PR TITLE
perf: 大規模グラフのフロント描画を高速化 (#84)

### DIFF
--- a/frontend/src/components/graph/DependencyGraph.tsx
+++ b/frontend/src/components/graph/DependencyGraph.tsx
@@ -32,6 +32,14 @@ const nodeTypes = {
   supercluster: SuperClusterNode,
 }
 
+// 描画ノード数がこれを超えたら MiniMap を省略する。MiniMap はノード1個につき
+// SVG 矩形を1個描くため、大規模グラフでは常時コストになる。
+const MINIMAP_HIDE_NODE_THRESHOLD = 150
+
+// フォーカス時にエッジアニメーション（流れる破線）を行う最大本数。
+// ハブノード選択で数百本が同時にアニメーションすると重くなるため上限を設ける。
+const FOCUS_ANIMATE_MAX_EDGES = 60
+
 type Props = {
   data: GraphResponse
   clusterMode: ClusterMode
@@ -99,10 +107,17 @@ function GraphInner({
 
   const edges = useMemo(() => {
     if (!focus) return layoutEdges
+    // フォーカスエッジが多すぎるときはアニメーションを切る（描画負荷対策）。
+    const animate = focus.edgeDir.size <= FOCUS_ANIMATE_MAX_EDGES
     return layoutEdges.map((e) => {
       const dir = focus.edgeDir.get(e.id)
       if (!dir) return { ...e, style: DIMMED_EDGE_STYLE, markerEnd: undefined, animated: false }
-      return { ...e, style: focusEdgeStyle(dir), markerEnd: focusEdgeMarker(dir), animated: true }
+      return {
+        ...e,
+        style: focusEdgeStyle(dir),
+        markerEnd: focusEdgeMarker(dir),
+        animated: animate,
+      }
     })
   }, [layoutEdges, focus])
 
@@ -138,6 +153,10 @@ function GraphInner({
       fitView
       minZoom={0.05}
       maxZoom={2.5}
+      onlyRenderVisibleElements
+      nodesDraggable={false}
+      nodesConnectable={false}
+      elevateNodesOnSelect={false}
       onNodeClick={handleNodeClick}
       onPaneClick={onClearSelection}
       proOptions={{ hideAttribution: false }}
@@ -149,12 +168,14 @@ function GraphInner({
         </Panel>
       )}
       <Controls position="bottom-left" />
-      <MiniMap
-        nodeColor={(n) =>
-          n.type === 'cluster' || n.type === 'supercluster' ? '#e7e5e4' : '#0d9488'
-        }
-        maskColor="rgba(250,250,249,0.6)"
-      />
+      {nodes.length <= MINIMAP_HIDE_NODE_THRESHOLD && (
+        <MiniMap
+          nodeColor={(n) =>
+            n.type === 'cluster' || n.type === 'supercluster' ? '#e7e5e4' : '#0d9488'
+          }
+          maskColor="rgba(250,250,249,0.6)"
+        />
+      )}
       <Panel position="bottom-right">
         <GraphControls
           clusterMode={clusterMode}

--- a/frontend/src/lib/graphLayout.ts
+++ b/frontend/src/lib/graphLayout.ts
@@ -232,6 +232,10 @@ export function layoutGraph(data: GraphResponse, expandedClusters: Set<string>):
             removedCount,
             hasChanged: changedCount > 0 || addedCount > 0 || removedCount > 0,
           } as SuperClusterNodeData,
+          // onlyRenderVisibleElements の交差判定はトップレベルの width/height を読む
+          // （style は参照しない）。style と同値を渡して間引き対象に含める。
+          width: SUPER_W,
+          height: SUPER_H,
           style: { width: SUPER_W, height: SUPER_H },
         })
 
@@ -258,6 +262,10 @@ export function layoutGraph(data: GraphResponse, expandedClusters: Set<string>):
             clusterColorHex: color.hex,
             clusterColorSoft: color.soft,
           } as ClusterGroupData,
+          // onlyRenderVisibleElements の交差判定はトップレベルの width/height を読む
+          // （style は参照しない）。style と同値を渡して間引き対象に含める。
+          width: clusterW,
+          height: clusterH,
           style: { width: clusterW, height: clusterH },
           draggable: false,
           selectable: true,

--- a/frontend/src/lib/graphLayout.ts
+++ b/frontend/src/lib/graphLayout.ts
@@ -13,8 +13,8 @@ import { inferLayer } from './layerInference'
 
 const LAYER_ORDER: LayerKind[] = ['ui', 'domain', 'data', 'infra', 'other']
 
-const NODE_W = 200
-const NODE_H = 60
+export const NODE_W = 200
+export const NODE_H = 60
 const COLS = 5
 const COL_STRIDE = 220
 const ROW_STRIDE = 140
@@ -276,6 +276,10 @@ export function layoutGraph(data: GraphResponse, expandedClusters: Set<string>):
             parentId: clusterId,
             extent: 'parent',
             position: { x, y },
+            // onlyRenderVisibleElements がビューポート外ノードを描画前に間引くには
+            // 寸法が必要。レイアウトが前提とする固定サイズをそのまま渡す。
+            width: NODE_W,
+            height: NODE_H,
             zIndex: 1,
             data: {
               label: n.name,

--- a/frontend/src/pages/AnalysisGraphView.tsx
+++ b/frontend/src/pages/AnalysisGraphView.tsx
@@ -24,6 +24,11 @@ import { Button } from '@/components/ui/button'
 
 type Props = { jobId: string }
 
+// デフォルト（初回表示）で自動展開する関数ノード数の予算。これを超える分の
+// 変更クラスタは折りたたんだまま開始し、大規模 PR で初期描画が重くなるのを防ぐ。
+// ユーザーは個別展開・すべて展開で随時開ける（展開時も仮想化で描画は軽い）。
+const AUTO_EXPAND_NODE_BUDGET = 300
+
 export default function AnalysisGraphView({ jobId }: Props) {
   const [clusterMode, setClusterMode] = useState<ClusterMode>('louvain')
   const { data, isLoading, error } = useGraph(jobId, true, clusterMode)
@@ -47,22 +52,35 @@ export default function AnalysisGraphView({ jobId }: Props) {
 
     const nodeMap = new Map(data.graph.nodes.map((n) => [n.id, n]))
 
+    // 展開キー(layer:clusterId)ごとにノード数・変更ノード数を集計する。
+    const keyStats = new Map<string, { nodeCount: number; changedCount: number }>()
     for (const cluster of data.clusters) {
-      const clusterKeys = new Set<string>()
-      let hasChanged = false
       for (const nid of cluster.nodes) {
         const n = nodeMap.get(nid)
-        if (n) {
-          const key = makeClusterKey(n.package, cluster.id)
-          clusterKeys.add(key)
-          allKeys.add(key)
-          if (n.changed || n.diff_status !== 'existing') hasChanged = true
-        }
-      }
-      if (hasChanged) {
-        clusterKeys.forEach((k) => defaultExpanded.add(k))
+        if (!n) continue
+        const key = makeClusterKey(n.package, cluster.id)
+        allKeys.add(key)
+        const s = keyStats.get(key) ?? { nodeCount: 0, changedCount: 0 }
+        s.nodeCount++
+        if (n.changed || n.diff_status !== 'existing') s.changedCount++
+        keyStats.set(key, s)
       }
     }
+
+    // 変更を含むキーを優先度順（変更ノード数 desc → ノード数 asc）に並べ、
+    // 描画ノード総数が予算を超えない範囲で自動展開する。
+    const candidates = [...keyStats.entries()]
+      .filter(([, s]) => s.changedCount > 0)
+      .sort((a, b) => b[1].changedCount - a[1].changedCount || a[1].nodeCount - b[1].nodeCount)
+
+    let used = 0
+    for (const [key, s] of candidates) {
+      // 最優先の1キーは予算超過でも必ず開く（常に何か展開された状態で見せる）。
+      if (used > 0 && used + s.nodeCount > AUTO_EXPAND_NODE_BUDGET) continue
+      defaultExpanded.add(key)
+      used += s.nodeCount
+    }
+
     return { defaultExpandedClusters: defaultExpanded, allClusterKeys: allKeys }
   }, [data])
 


### PR DESCRIPTION
## 概要
ノード/エッジ数が多いと React Flow が全要素を常時 DOM/SVG に描画して重くなる問題に対し、4つの対策を入れる。

Closes #84

## 変更点
1. **仮想化**: `onlyRenderVisibleElements` でビューポート外を間引く。関数ノードに明示 `width/height`（200×60）を付与し描画前の間引きを効かせる
2. **インタラクション削減**: `nodesDraggable` / `nodesConnectable` / `elevateNodesOnSelect` を `false`（レイアウトは計算済みでドラッグ不要）
3. **自動展開の上限**: デフォルト表示の自動展開に関数ノード数予算（300）。変更ノード数の多いクラスタ優先で展開し超過分は折りたたみ維持
4. **スケール対応**: ノード150超で MiniMap 省略、フォーカスエッジ60超でアニメーション抑制

## 設計判断
「すべて展開」ボタンは上限をかけず全展開のままにした。仮想化で全展開しても描画は軽く、「全部見せる」ボタンに上限をかけるのは挙動として矛盾するため。上限は初期表示の自動展開に集約。

## Test plan
- [x] `npm run lint`（eslint）: エラーなし
- [x] `npx tsc -b`: 型エラーなし
- [x] `prettier --write`: 整形済み
- [ ] **【最重要】`onlyRenderVisibleElements` + 親子ノード（`extent: parent`）の表示崩れ**: クラスタ内の関数ノードがパン/ズームで消えたり寸法ズレで重ならないか（React Flow の既知の注意点）
- [ ] デフォルト表示で変更クラスタが予算内で適切に展開され、大規模 PR でも初期表示が軽いか
- [ ] 「すべて展開」「折りたたむ」「変更ノードに寄せる」「ノードクリックでフォーカス/詳細パネル」が従来どおり動くか
- [ ] 小規模 PR でリグレッション（MiniMap が消えない等）がないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)