### PR TITLE
feat: bench -both モード + callgraph 内訳計時（#82 PR-A 計測基盤）

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,2 +1,2 @@
 tmp/
-bench
+/bench

--- a/backend/cmd/bench/main.go
+++ b/backend/cmd/bench/main.go
@@ -1,5 +1,8 @@
 // bench は解析パイプラインの各フェーズの所要時間を計測するCLIツール。
-// 使い方: bench -token <GitHub PAT> -pr <PR URL>
+// 使い方:
+//
+//	bench -token <GitHub PAT> -owner <owner> -repo <repo> -pr <PR番号>        # head 側のみ（従来）
+//	bench -token <GitHub PAT> -owner <owner> -repo <repo> -pr <PR番号> -both  # worker と同じ base+head 並列 → Merge → Cluster
 package main
 
 import (
@@ -9,6 +12,8 @@ import (
 	"log"
 	"os"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
 	"github.com/s-sh1m0/u-22_procon/backend/internal/infra/analyzer"
@@ -21,6 +26,7 @@ func main() {
 	owner := flag.String("owner", "s-sh1m0", "repo owner")
 	repo := flag.String("repo", "u-22_procon", "repo name")
 	prNum := flag.Int("pr", 21, "PR number")
+	both := flag.Bool("both", false, "base+head を並列構築し Merge → Cluster まで実行する（worker と同じパイプライン）")
 	flag.Parse()
 
 	if *token == "" {
@@ -29,7 +35,11 @@ func main() {
 
 	ctx := context.Background()
 
-	log.Printf("=== bench start: %s/%s#%d ===", *owner, *repo, *prNum)
+	mode := "head-only"
+	if *both {
+		mode = "both"
+	}
+	log.Printf("=== bench start: %s/%s#%d (%s) ===", *owner, *repo, *prNum, mode)
 	tTotal := time.Now()
 
 	// 1. PR メタ情報取得
@@ -39,7 +49,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("GetPR: %v", err)
 	}
-	log.Printf("[1] GetPR took %s (head=%s)", time.Since(t0), prInfo.HeadSHA[:8])
+	log.Printf("[1] GetPR took %s (head=%s base=%s)", time.Since(t0), shortSHA(prInfo.HeadSHA), shortSHA(prInfo.BaseSHA))
 
 	// 2. 変更ファイル取得
 	t1 := time.Now()
@@ -52,36 +62,44 @@ func main() {
 		fmt.Printf("    %s (%s)\n", f.Filename, f.Status)
 	}
 
+	if *both {
+		runBoth(ctx, *prInfo, *token, changed)
+	} else {
+		runHeadOnly(ctx, *prInfo, *token, changed)
+	}
+
+	log.Printf("=== total: %s ===", time.Since(tTotal))
+}
+
+// runHeadOnly は head 側のみを clone → Build → Cluster する（従来の bench 挙動）。
+func runHeadOnly(ctx context.Context, prInfo domain.PRInfo, token string, changed []domain.ChangedFile) {
 	// 3. clone + FastLoad + 近傍Load
-	t2 := time.Now()
+	t0 := time.Now()
 	sourceTree := analyzer.NewSourceTree(analyzer.NewGitCloner(), analyzer.NewGoPackageLoader())
-	prepared, err := sourceTree.Prepare(ctx, *prInfo, *token, changed)
+	prepared, err := sourceTree.Prepare(ctx, prInfo, token, changed)
 	if err != nil {
 		log.Fatalf("Prepare: %v", err)
 	}
 	defer func() { _ = prepared.Cleanup() }()
-	log.Printf("[3] Prepare (clone+load) took %s", time.Since(t2))
+	log.Printf("[3] Prepare (clone+load) took %s", time.Since(t0))
 	log.Printf("    packages loaded: %d, changed pkgs: %v", len(prepared.Packages), prepared.ChangedPackages)
 
 	// 4. コールグラフ構築
-	t3 := time.Now()
+	t1 := time.Now()
 	cgBuilder := analyzer.NewGoCallGraphBuilder()
-	graph, err := cgBuilder.Build(ctx, prepared.Packages, prepared.ChangedPackages, prepared.ChangedFileAbsPaths, prepared.RootDir)
+	graph, err := cgBuilder.Build(ctx, prepared.Packages, prepared.ChangedPackages, prepared.ChangedFileAbsPaths, prepared.RepoRoot)
 	if err != nil {
 		log.Fatalf("Build: %v", err)
 	}
-	log.Printf("[4] Build callgraph took %s (nodes=%d edges=%d)", time.Since(t3), len(graph.Nodes), len(graph.Edges))
+	log.Printf("[4] Build callgraph took %s (nodes=%d edges=%d)", time.Since(t1), len(graph.Nodes), len(graph.Edges))
 
 	// 5. クラスタリング
-	t4 := time.Now()
+	t2 := time.Now()
 	clusterer := cluster.NewLouvainClusterer()
-	_, err = clusterer.Cluster(ctx, graph)
-	if err != nil {
+	if _, err := clusterer.Cluster(ctx, graph); err != nil {
 		log.Fatalf("Cluster: %v", err)
 	}
-	log.Printf("[5] Cluster took %s", time.Since(t4))
-
-	log.Printf("=== total: %s ===", time.Since(tTotal))
+	log.Printf("[5] Cluster took %s", time.Since(t2))
 
 	// 6. グラフの中身確認（外部パッケージが混じっていないかチェック）
 	fmt.Println("\n--- nodes (package) ---")
@@ -92,6 +110,108 @@ func main() {
 	for pkg, cnt := range pkgCount {
 		fmt.Printf("  %s (%d nodes)\n", pkg, cnt)
 	}
+}
 
-	_ = domain.PRInfo{}
+// runBoth は worker と同じパイプライン（base+head 並列構築 → Merge → cycles/violations
+// 検出 → Cluster）を実行し、ノード/エッジ数のサマリを出力する。
+// PR-F（依存の export data 化 / #82）の A/B 比較ゲートとして、新旧実装で
+// このサマリのノード/エッジ数が完全一致することの確認に使う。
+func runBoth(ctx context.Context, prInfo domain.PRInfo, token string, changed []domain.ChangedFile) {
+	sourceTree := analyzer.NewSourceTree(analyzer.NewGitCloner(), analyzer.NewGoPackageLoader())
+	cgBuilder := analyzer.NewGoCallGraphBuilder()
+
+	// 3. base+head を並列構築（worker.buildBothGraphs と同じ構成）
+	t0 := time.Now()
+	var headGraph, baseGraph *domain.Graph
+	cleanups := make([]func() error, 2)
+	defer func() {
+		for _, c := range cleanups {
+			if c != nil {
+				_ = c()
+			}
+		}
+	}()
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		t := time.Now()
+		prepared, err := sourceTree.Prepare(egCtx, prInfo, token, changed)
+		if err != nil {
+			return fmt.Errorf("head prepare: %w", err)
+		}
+		cleanups[0] = prepared.Cleanup
+		log.Printf("[head] Prepare took %s (pkgs=%d, changed pkgs=%d)", time.Since(t), len(prepared.Packages), len(prepared.ChangedPackages))
+		t = time.Now()
+		g, err := cgBuilder.Build(egCtx, prepared.Packages, prepared.ChangedPackages, prepared.ChangedFileAbsPaths, prepared.RepoRoot)
+		if err != nil {
+			return fmt.Errorf("head build: %w", err)
+		}
+		log.Printf("[head] Build took %s (nodes=%d edges=%d)", time.Since(t), len(g.Nodes), len(g.Edges))
+		headGraph = g
+		return nil
+	})
+	eg.Go(func() error {
+		t := time.Now()
+		baseChanged := domain.NormalizeChangedForBase(changed)
+		prepared, err := sourceTree.PrepareAtSHA(egCtx, prInfo, token, prInfo.BaseSHA, baseChanged)
+		if err != nil {
+			return fmt.Errorf("base prepare: %w", err)
+		}
+		cleanups[1] = prepared.Cleanup
+		log.Printf("[base] Prepare took %s (pkgs=%d, changed pkgs=%d)", time.Since(t), len(prepared.Packages), len(prepared.ChangedPackages))
+		t = time.Now()
+		g, err := cgBuilder.Build(egCtx, prepared.Packages, prepared.ChangedPackages, prepared.ChangedFileAbsPaths, prepared.RepoRoot)
+		if err != nil {
+			return fmt.Errorf("base build: %w", err)
+		}
+		log.Printf("[base] Build took %s (nodes=%d edges=%d)", time.Since(t), len(g.Nodes), len(g.Edges))
+		baseGraph = g
+		return nil
+	})
+	if err := eg.Wait(); err != nil {
+		log.Fatalf("build base/head graphs: %v", err)
+	}
+	log.Printf("[3] parallel base+head build took %s", time.Since(t0))
+
+	// 4. Merge + cycles/violations 検出
+	t1 := time.Now()
+	diffGraph := analyzer.MergeWithDiffStatus(baseGraph, headGraph)
+	cycles := analyzer.DetectNewCycles(baseGraph, headGraph)
+	violations := analyzer.DetectLayeringViolations(diffGraph)
+	log.Printf("[4] Merge+Detect took %s", time.Since(t1))
+
+	// 5. クラスタリング
+	t2 := time.Now()
+	clusterer := cluster.NewLouvainClusterer()
+	result, err := clusterer.Cluster(ctx, diffGraph)
+	if err != nil {
+		log.Fatalf("Cluster: %v", err)
+	}
+	log.Printf("[5] Cluster took %s", time.Since(t2))
+
+	// 6. ノード/エッジ数サマリ（A/B 比較で完全一致を確認する対象）
+	nodeCnt := map[domain.DiffStatus]int{}
+	for _, n := range diffGraph.Nodes {
+		nodeCnt[n.DiffStatus]++
+	}
+	edgeCnt := map[domain.DiffStatus]int{}
+	for _, e := range diffGraph.Edges {
+		edgeCnt[e.Status]++
+	}
+	fmt.Println("\n--- summary ---")
+	fmt.Printf("head  : nodes=%d edges=%d\n", len(headGraph.Nodes), len(headGraph.Edges))
+	fmt.Printf("base  : nodes=%d edges=%d\n", len(baseGraph.Nodes), len(baseGraph.Edges))
+	fmt.Printf("merged: nodes=%d (existing=%d added=%d removed=%d)\n",
+		len(diffGraph.Nodes), nodeCnt[domain.DiffStatusExisting], nodeCnt[domain.DiffStatusAdded], nodeCnt[domain.DiffStatusRemoved])
+	fmt.Printf("        edges=%d (existing=%d added=%d removed=%d)\n",
+		len(diffGraph.Edges), edgeCnt[domain.DiffStatusExisting], edgeCnt[domain.DiffStatusAdded], edgeCnt[domain.DiffStatusRemoved])
+	fmt.Printf("result: clusters=%d cycles=%d violations=%d\n", len(result.Clusters), len(cycles), len(violations))
+}
+
+// shortSHA は SHA の先頭8桁を返す（8桁未満ならそのまま）。
+func shortSHA(sha string) string {
+	if len(sha) >= 8 {
+		return sha[:8]
+	}
+	return sha
 }

--- a/backend/cmd/bench/main.go
+++ b/backend/cmd/bench/main.go
@@ -86,7 +86,7 @@ func runHeadOnly(ctx context.Context, prInfo domain.PRInfo, token string, change
 	sourceTree := analyzer.NewSourceTree(analyzer.NewGitCloner(), analyzer.NewGoPackageLoader())
 	prepared, err := sourceTree.Prepare(ctx, prInfo, token, changed)
 	if err != nil {
-		return fmt.Errorf("Prepare: %w", err)
+		return fmt.Errorf("prepare: %w", err)
 	}
 	defer func() { _ = prepared.Cleanup() }()
 	log.Printf("[3] Prepare (clone+load) took %s", time.Since(t0))
@@ -97,7 +97,7 @@ func runHeadOnly(ctx context.Context, prInfo domain.PRInfo, token string, change
 	cgBuilder := analyzer.NewGoCallGraphBuilder()
 	graph, err := cgBuilder.Build(ctx, prepared.Packages, prepared.ChangedPackages, prepared.ChangedFileAbsPaths, prepared.RepoRoot)
 	if err != nil {
-		return fmt.Errorf("Build: %w", err)
+		return fmt.Errorf("build: %w", err)
 	}
 	log.Printf("[4] Build callgraph took %s (nodes=%d edges=%d)", time.Since(t1), len(graph.Nodes), len(graph.Edges))
 
@@ -105,7 +105,7 @@ func runHeadOnly(ctx context.Context, prInfo domain.PRInfo, token string, change
 	t2 := time.Now()
 	clusterer := cluster.NewLouvainClusterer()
 	if _, err := clusterer.Cluster(ctx, graph); err != nil {
-		return fmt.Errorf("Cluster: %w", err)
+		return fmt.Errorf("cluster: %w", err)
 	}
 	log.Printf("[5] Cluster took %s", time.Since(t2))
 
@@ -196,7 +196,7 @@ func runBoth(ctx context.Context, prInfo domain.PRInfo, token string, changed []
 	clusterer := cluster.NewLouvainClusterer()
 	result, err := clusterer.Cluster(ctx, diffGraph)
 	if err != nil {
-		return fmt.Errorf("Cluster: %w", err)
+		return fmt.Errorf("cluster: %w", err)
 	}
 	log.Printf("[5] Cluster took %s", time.Since(t2))
 

--- a/backend/cmd/bench/main.go
+++ b/backend/cmd/bench/main.go
@@ -62,23 +62,31 @@ func main() {
 		fmt.Printf("    %s (%s)\n", f.Filename, f.Status)
 	}
 
+	// runBoth/runHeadOnly は clone した一時ディレクトリを defer で削除する。
+	// ここで直接 log.Fatalf すると os.Exit で defer が飛び一時ディレクトリが
+	// 残留するため、error を受け取ってから終了する（bench は A/B 計測で
+	// 繰り返し回すのでリークが溜まりやすい）。
 	if *both {
-		runBoth(ctx, *prInfo, *token, changed)
+		err = runBoth(ctx, *prInfo, *token, changed)
 	} else {
-		runHeadOnly(ctx, *prInfo, *token, changed)
+		err = runHeadOnly(ctx, *prInfo, *token, changed)
+	}
+	if err != nil {
+		log.Fatalf("bench failed: %v", err)
 	}
 
 	log.Printf("=== total: %s ===", time.Since(tTotal))
 }
 
 // runHeadOnly は head 側のみを clone → Build → Cluster する（従来の bench 挙動）。
-func runHeadOnly(ctx context.Context, prInfo domain.PRInfo, token string, changed []domain.ChangedFile) {
+// エラー時も defer した Cleanup が走るよう、log.Fatalf せず error を返す。
+func runHeadOnly(ctx context.Context, prInfo domain.PRInfo, token string, changed []domain.ChangedFile) error {
 	// 3. clone + FastLoad + 近傍Load
 	t0 := time.Now()
 	sourceTree := analyzer.NewSourceTree(analyzer.NewGitCloner(), analyzer.NewGoPackageLoader())
 	prepared, err := sourceTree.Prepare(ctx, prInfo, token, changed)
 	if err != nil {
-		log.Fatalf("Prepare: %v", err)
+		return fmt.Errorf("Prepare: %w", err)
 	}
 	defer func() { _ = prepared.Cleanup() }()
 	log.Printf("[3] Prepare (clone+load) took %s", time.Since(t0))
@@ -89,7 +97,7 @@ func runHeadOnly(ctx context.Context, prInfo domain.PRInfo, token string, change
 	cgBuilder := analyzer.NewGoCallGraphBuilder()
 	graph, err := cgBuilder.Build(ctx, prepared.Packages, prepared.ChangedPackages, prepared.ChangedFileAbsPaths, prepared.RepoRoot)
 	if err != nil {
-		log.Fatalf("Build: %v", err)
+		return fmt.Errorf("Build: %w", err)
 	}
 	log.Printf("[4] Build callgraph took %s (nodes=%d edges=%d)", time.Since(t1), len(graph.Nodes), len(graph.Edges))
 
@@ -97,7 +105,7 @@ func runHeadOnly(ctx context.Context, prInfo domain.PRInfo, token string, change
 	t2 := time.Now()
 	clusterer := cluster.NewLouvainClusterer()
 	if _, err := clusterer.Cluster(ctx, graph); err != nil {
-		log.Fatalf("Cluster: %v", err)
+		return fmt.Errorf("Cluster: %w", err)
 	}
 	log.Printf("[5] Cluster took %s", time.Since(t2))
 
@@ -110,13 +118,16 @@ func runHeadOnly(ctx context.Context, prInfo domain.PRInfo, token string, change
 	for pkg, cnt := range pkgCount {
 		fmt.Printf("  %s (%d nodes)\n", pkg, cnt)
 	}
+	return nil
 }
 
 // runBoth は worker と同じパイプライン（base+head 並列構築 → Merge → cycles/violations
 // 検出 → Cluster）を実行し、ノード/エッジ数のサマリを出力する。
 // PR-F（依存の export data 化 / #82）の A/B 比較ゲートとして、新旧実装で
 // このサマリのノード/エッジ数が完全一致することの確認に使う。
-func runBoth(ctx context.Context, prInfo domain.PRInfo, token string, changed []domain.ChangedFile) {
+// エラー時も defer した Cleanup（base/head 2つの一時ディレクトリ）が走るよう、
+// log.Fatalf せず error を返す。
+func runBoth(ctx context.Context, prInfo domain.PRInfo, token string, changed []domain.ChangedFile) error {
 	sourceTree := analyzer.NewSourceTree(analyzer.NewGitCloner(), analyzer.NewGoPackageLoader())
 	cgBuilder := analyzer.NewGoCallGraphBuilder()
 
@@ -169,7 +180,7 @@ func runBoth(ctx context.Context, prInfo domain.PRInfo, token string, changed []
 		return nil
 	})
 	if err := eg.Wait(); err != nil {
-		log.Fatalf("build base/head graphs: %v", err)
+		return fmt.Errorf("build base/head graphs: %w", err)
 	}
 	log.Printf("[3] parallel base+head build took %s", time.Since(t0))
 
@@ -185,7 +196,7 @@ func runBoth(ctx context.Context, prInfo domain.PRInfo, token string, changed []
 	clusterer := cluster.NewLouvainClusterer()
 	result, err := clusterer.Cluster(ctx, diffGraph)
 	if err != nil {
-		log.Fatalf("Cluster: %v", err)
+		return fmt.Errorf("Cluster: %w", err)
 	}
 	log.Printf("[5] Cluster took %s", time.Since(t2))
 
@@ -206,6 +217,7 @@ func runBoth(ctx context.Context, prInfo domain.PRInfo, token string, changed []
 	fmt.Printf("        edges=%d (existing=%d added=%d removed=%d)\n",
 		len(diffGraph.Edges), edgeCnt[domain.DiffStatusExisting], edgeCnt[domain.DiffStatusAdded], edgeCnt[domain.DiffStatusRemoved])
 	fmt.Printf("result: clusters=%d cycles=%d violations=%d\n", len(result.Clusters), len(cycles), len(violations))
+	return nil
 }
 
 // shortSHA は SHA の先頭8桁を返す（8桁未満ならそのまま）。

--- a/backend/internal/domain/analysis.go
+++ b/backend/internal/domain/analysis.go
@@ -37,6 +37,29 @@ type ChangedFile struct {
 	Patch            string
 }
 
+// NormalizeChangedForBase は head 基準の changed リストを base 側のリポジトリで使える形に正規化する。
+//   - Status=added は base 側に存在しないため除外
+//   - Status=renamed は Filename を PreviousFilename に置き換える
+//   - その他（modified, removed）はそのまま
+func NormalizeChangedForBase(changed []ChangedFile) []ChangedFile {
+	out := make([]ChangedFile, 0, len(changed))
+	for _, f := range changed {
+		switch f.Status {
+		case FileStatusAdded:
+			continue
+		case FileStatusRenamed:
+			cp := f
+			if cp.PreviousFilename != "" {
+				cp.Filename = cp.PreviousFilename
+			}
+			out = append(out, cp)
+		default:
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
 // DiffFile はPRで変更されたファイルの before/after 全文を保持する。
 type DiffFile struct {
 	Filename      string // head 側のパス（removed は base 側のパス）

--- a/backend/internal/domain/analysis_test.go
+++ b/backend/internal/domain/analysis_test.go
@@ -1,0 +1,76 @@
+package domain
+
+import "testing"
+
+func TestNormalizeChangedForBase(t *testing.T) {
+	tests := []struct {
+		name    string
+		changed []ChangedFile
+		want    []ChangedFile
+	}{
+		{
+			name:    "空リストは空を返す",
+			changed: nil,
+			want:    []ChangedFile{},
+		},
+		{
+			name: "added は base 側に存在しないため除外",
+			changed: []ChangedFile{
+				{Filename: "pkg/a/new.go", Status: FileStatusAdded},
+				{Filename: "pkg/b/mod.go", Status: FileStatusModified},
+			},
+			want: []ChangedFile{
+				{Filename: "pkg/b/mod.go", Status: FileStatusModified},
+			},
+		},
+		{
+			name: "renamed は Filename を PreviousFilename に置換",
+			changed: []ChangedFile{
+				{Filename: "pkg/a/new.go", PreviousFilename: "pkg/a/old.go", Status: FileStatusRenamed},
+			},
+			want: []ChangedFile{
+				{Filename: "pkg/a/old.go", PreviousFilename: "pkg/a/old.go", Status: FileStatusRenamed},
+			},
+		},
+		{
+			name: "renamed でも PreviousFilename が空なら Filename を維持",
+			changed: []ChangedFile{
+				{Filename: "pkg/a/new.go", Status: FileStatusRenamed},
+			},
+			want: []ChangedFile{
+				{Filename: "pkg/a/new.go", Status: FileStatusRenamed},
+			},
+		},
+		{
+			name: "modified と removed はそのまま",
+			changed: []ChangedFile{
+				{Filename: "pkg/a/mod.go", Status: FileStatusModified},
+				{Filename: "pkg/b/rm.go", Status: FileStatusRemoved},
+			},
+			want: []ChangedFile{
+				{Filename: "pkg/a/mod.go", Status: FileStatusModified},
+				{Filename: "pkg/b/rm.go", Status: FileStatusRemoved},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeChangedForBase(tt.changed)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len=%d want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i].Filename != tt.want[i].Filename {
+					t.Errorf("[%d] Filename=%q want %q", i, got[i].Filename, tt.want[i].Filename)
+				}
+				if got[i].PreviousFilename != tt.want[i].PreviousFilename {
+					t.Errorf("[%d] PreviousFilename=%q want %q", i, got[i].PreviousFilename, tt.want[i].PreviousFilename)
+				}
+				if got[i].Status != tt.want[i].Status {
+					t.Errorf("[%d] Status=%q want %q", i, got[i].Status, tt.want[i].Status)
+				}
+			}
+		})
+	}
+}

--- a/backend/internal/infra/analyzer/callgraph.go
+++ b/backend/internal/infra/analyzer/callgraph.go
@@ -2,7 +2,9 @@ package analyzer
 
 import (
 	"context"
+	"log"
 	"path/filepath"
+	"time"
 
 	"golang.org/x/tools/go/callgraph"
 	"golang.org/x/tools/go/callgraph/cha"
@@ -65,12 +67,16 @@ func (b *GoCallGraphBuilder) Build(_ context.Context, pkgs []*packages.Package, 
 	}
 
 	// 2. SSA プログラムを構築（プロジェクト内パッケージのみ）
+	tSSA := time.Now()
 	prog, _ := ssautil.AllPackages(projectPkgs, ssa.InstantiateGenerics)
 	prog.Build()
+	ssaTook := time.Since(tSSA)
 
 	// 3. CHA でコールグラフ構築（エントリポイント不要 → ライブラリにも適用可）
+	tCHA := time.Now()
 	cg := cha.CallGraph(prog)
 	cg.DeleteSyntheticNodes()
+	chaTook := time.Since(tCHA)
 
 	// 4. 変更パッケージ ID セット
 	changedSet := make(map[string]struct{}, len(changedPkgIDs))
@@ -85,6 +91,7 @@ func (b *GoCallGraphBuilder) Build(_ context.Context, pkgs []*packages.Package, 
 	}
 
 	// 5. 変更パッケージの関数を起点に BFS（双方向、maxDepth ホップ）
+	tBFS := time.Now()
 	type entry struct {
 		node  *callgraph.Node
 		depth int
@@ -139,10 +146,13 @@ func (b *GoCallGraphBuilder) Build(_ context.Context, pkgs []*packages.Package, 
 		}
 	}
 
+	bfsTook := time.Since(tBFS)
+
 	// 6. 収集ノード・エッジを domain.Graph に変換
 	// 無名関数（クロージャ）は囲うトップレベル親関数に畳み込む。複数の callgraph
 	// ノード（親本体 + 各クロージャ）が同一 NodeID を指すため、ノードは重複排除し、
 	// エッジは親 NodeID へ付け替えたうえで自己ループ・重複を除去する。
+	tConv := time.Now()
 	nodeIDMap := make(map[*callgraph.Node]domain.NodeID, len(collected))
 	nodeSeen := make(map[domain.NodeID]struct{}, len(collected))
 	var nodes []domain.Node
@@ -195,6 +205,12 @@ func (b *GoCallGraphBuilder) Build(_ context.Context, pkgs []*packages.Package, 
 			edges = append(edges, domain.Edge{From: callerID, To: calleeID, Status: domain.DiffStatusExisting})
 		}
 	}
+
+	// 内訳計時ログ: #82 のボトルネック計測用。SSA/CHA が支配的か BFS/変換が
+	// 支配的かを 1 行で判別できるようにする。
+	log.Printf("analyzer: callgraph breakdown: ssa=%s cha=%s bfs=%s convert=%s (pkgs=%d, cha nodes=%d, collected=%d, out nodes=%d edges=%d)",
+		ssaTook, chaTook, bfsTook, time.Since(tConv),
+		len(projectPkgs), len(cg.Nodes), len(collected), len(nodes), len(edges))
 
 	return &domain.Graph{Nodes: nodes, Edges: edges}, nil
 }

--- a/backend/internal/infra/job/worker.go
+++ b/backend/internal/infra/job/worker.go
@@ -278,7 +278,7 @@ func (w *Worker) buildBothGraphs(
 	})
 
 	eg.Go(func() error {
-		baseChanged := normalizeChangedForBase(changed)
+		baseChanged := domain.NormalizeChangedForBase(changed)
 		prepared, err := w.sourceTree.PrepareAtSHA(egCtx, pr, token, pr.BaseSHA, baseChanged)
 		if err != nil {
 			return fmt.Errorf("base prepare: %w", err)
@@ -297,29 +297,6 @@ func (w *Worker) buildBothGraphs(
 		return nil, nil, cleanups, err
 	}
 	return head, base, cleanups, nil
-}
-
-// normalizeChangedForBase は head 基準の changed リストを base 側のリポジトリで使える形に正規化する。
-//   - Status=added は base 側に存在しないため除外
-//   - Status=renamed は Filename を PreviousFilename に置き換える
-//   - その他（modified, removed）はそのまま
-func normalizeChangedForBase(changed []domain.ChangedFile) []domain.ChangedFile {
-	out := make([]domain.ChangedFile, 0, len(changed))
-	for _, f := range changed {
-		switch f.Status {
-		case domain.FileStatusAdded:
-			continue
-		case domain.FileStatusRenamed:
-			cp := f
-			if cp.PreviousFilename != "" {
-				cp.Filename = cp.PreviousFilename
-			}
-			out = append(out, cp)
-		default:
-			out = append(out, f)
-		}
-	}
-	return out
 }
 
 func workerRandomID() string {


### PR DESCRIPTION
親: #82（Phase 0 / PR-A: 計測基盤）

## 背景

#82 の施策（特に PR-F: 依存の export data 化）は「新旧実装でノード/エッジ数が完全一致すること」を計測ゲートにする。その A/B 比較を PAT だけで反復実行できる基盤が必要。

## 変更内容

1. **bench に `-both` フラグを追加**（`cmd/bench/main.go`）
   - worker.process と同じ経路（base+head 並列構築 → Merge → cycles/violations 検出 → Cluster）を再現
   - ノード/エッジ数を diff status（existing/added/removed）別にサマリ出力
   - あわせて Build へ渡す rootDir を worker と同じ `RepoRoot` に修正（従来は `RootDir` = go.mod 基点で、モノレポだとノードのファイルパスが worker と食い違っていた）
2. **callgraph Build に内訳計時ログを追加**（`analyzer/callgraph.go`）
   - `ssa / cha / bfs / convert` の所要時間と CHA ノード数・収集ノード数を 1 行で出力
3. **`normalizeChangedForBase` を domain へ移動**（`domain.NormalizeChangedForBase`）
   - bench と worker で base 側パス正規化の単一実装を共有（複製するとロジック乖離時に A/B 計測が無言で狂うため）。テーブル駆動テスト追加
4. `backend/.gitignore` の `bench` を `/bench` に修正（ビルド成果物のみに限定。`cmd/bench/` が誤って ignore されていた）

## 動作確認（実施済み）

- `gofmt` / `go vet` / `go test ./...` すべて通過（Docker、`--build` 付き）
- 実 PAT で `-both` を実機実行（本リポジトリ PR #21）:

```
[base] Build took 1.41s (nodes=14 edges=2)
[head] Build took 1.94s (nodes=33 edges=29)
analyzer: callgraph breakdown: ssa=1.10s cha=833ms bfs=7.0ms convert=171µs (pkgs=6, cha nodes=29406, collected=35, ...)
--- summary ---
head  : nodes=33 edges=29
base  : nodes=14 edges=2
merged: nodes=33 (existing=14 added=19 removed=0)
        edges=29 (existing=2 added=27 removed=0)
result: clusters=10 cycles=0 violations=0
```

早速、6 pkgs のロードに対し CHA ノードが 29,406 個（依存閉包の SSA/CHA 構築）という PR-F の狙いどおりのボトルネックが数字で確認できている。

## Test plan

- [x] CI（lint / test）が通ること
- [x] （任意）手元の PAT で `docker compose run --rm -e GITHUB_TOKEN=<PAT> backend go run ./cmd/bench -pr <番号> -both` を実行し、サマリが出力されること

UI への影響なし（バックエンド CLI と計測ログのみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)