### PR TITLE
fix: applyClusterMode が LayerViolations を落とし violations が常に空になるバグを修正 (#95)

### DIFF
--- a/backend/internal/usecase/regroup.go
+++ b/backend/internal/usecase/regroup.go
@@ -19,15 +19,17 @@ func applyClusterMode(result *domain.ClusterResult, mode domain.ClusterMode) *do
 	switch mode {
 	case domain.ClusterModeLouvain:
 		return &domain.ClusterResult{
-			Clusters: labelClusters(result.Clusters, result.Graph),
-			Graph:    result.Graph,
-			Cycles:   result.Cycles,
+			Clusters:        labelClusters(result.Clusters, result.Graph),
+			Graph:           result.Graph,
+			Cycles:          result.Cycles,
+			LayerViolations: result.LayerViolations,
 		}
 	case domain.ClusterModePackage, domain.ClusterModeFile:
 		return &domain.ClusterResult{
-			Clusters: regroupBy(result.Graph, mode),
-			Graph:    result.Graph,
-			Cycles:   result.Cycles,
+			Clusters:        regroupBy(result.Graph, mode),
+			Graph:           result.Graph,
+			Cycles:          result.Cycles,
+			LayerViolations: result.LayerViolations,
 		}
 	default:
 		return result

--- a/backend/internal/usecase/regroup_test.go
+++ b/backend/internal/usecase/regroup_test.go
@@ -72,9 +72,10 @@ func TestRegroupBy_File(t *testing.T) {
 
 func TestApplyClusterMode_LouvainLabelsClusters(t *testing.T) {
 	orig := &domain.ClusterResult{
-		Clusters: []domain.Cluster{{ID: 0, Label: "raw", Nodes: []domain.NodeID{"a", "b"}}},
-		Graph:    sampleGraph(),
-		Cycles:   []domain.Cycle{{ID: 3, Nodes: []domain.NodeID{"a", "b"}, IsNew: true}},
+		Clusters:        []domain.Cluster{{ID: 0, Label: "raw", Nodes: []domain.NodeID{"a", "b"}}},
+		Graph:           sampleGraph(),
+		Cycles:          []domain.Cycle{{ID: 3, Nodes: []domain.NodeID{"a", "b"}, IsNew: true}},
+		LayerViolations: []domain.LayerViolation{{From: "d", To: "a", FromLayer: "domain", ToLayer: "infra", IsNew: true}},
 	}
 	got := applyClusterMode(orig, domain.ClusterModeLouvain)
 	if got == nil {
@@ -94,6 +95,10 @@ func TestApplyClusterMode_LouvainLabelsClusters(t *testing.T) {
 	if len(got.Cycles) != 1 || got.Cycles[0].ID != 3 {
 		t.Errorf("Cycles not preserved: %+v", got.Cycles)
 	}
+	// LayerViolations も保持される（欠落すると /api/graph の violations が常に空になる回帰）。
+	if len(got.LayerViolations) != 1 || got.LayerViolations[0].From != "d" {
+		t.Errorf("LayerViolations not preserved: %+v", got.LayerViolations)
+	}
 }
 
 func TestApplyClusterMode_NilResult(t *testing.T) {
@@ -104,13 +109,18 @@ func TestApplyClusterMode_NilResult(t *testing.T) {
 
 func TestApplyClusterMode_PreservesCycles(t *testing.T) {
 	orig := &domain.ClusterResult{
-		Clusters: []domain.Cluster{{ID: 0, Label: "louvain-cluster", Nodes: []domain.NodeID{"a", "b"}}},
-		Graph:    sampleGraph(),
-		Cycles:   []domain.Cycle{{ID: 7, Nodes: []domain.NodeID{"a", "b"}, IsNew: true}},
+		Clusters:        []domain.Cluster{{ID: 0, Label: "louvain-cluster", Nodes: []domain.NodeID{"a", "b"}}},
+		Graph:           sampleGraph(),
+		Cycles:          []domain.Cycle{{ID: 7, Nodes: []domain.NodeID{"a", "b"}, IsNew: true}},
+		LayerViolations: []domain.LayerViolation{{From: "d", To: "a", FromLayer: "domain", ToLayer: "infra", IsNew: true}},
 	}
 	got := applyClusterMode(orig, domain.ClusterModePackage)
 	if len(got.Cycles) != 1 || got.Cycles[0].ID != 7 {
 		t.Errorf("Cycles not preserved: %+v", got.Cycles)
+	}
+	// Package/File モードでも LayerViolations は保持される。
+	if len(got.LayerViolations) != 1 || got.LayerViolations[0].From != "d" {
+		t.Errorf("LayerViolations not preserved: %+v", got.LayerViolations)
 	}
 	if got.Clusters[0].Label == "louvain-cluster" {
 		t.Error("Clusters should be regrouped, but kept Louvain label")


### PR DESCRIPTION
親: #95 / #79

## 背景

`usecase/regroup.go` の `applyClusterMode` が `ClusterMode` に応じて `ClusterResult` を再構築する際、Louvain / Package / File のすべての分岐で `LayerViolations` を引き継いでいなかった。このため `/api/graph` が返す `violations` が常に空になり、フロントの LayeringAlert（依存方向の逆転を通知する UI）が一切機能していなかった。

`Cycles` は保持されていたが `LayerViolations` だけ欠落していた。

## 施策

- `applyClusterMode` の Louvain / Package / File 全分岐で `LayerViolations: result.LayerViolations` を保持
- 回帰テストを追加（Louvain・Package の両モードで `LayerViolations` が保持されることを検証）

## 確認

- `docker run --rm -v $(pwd)/backend:/app ... golang:1.26 sh -c 'gofmt -w . && go vet ./...'` → clean
- `go test ./...` → 全パッケージ pass（`usecase` の新規回帰テスト含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)