### PR TITLE
refactor: worker の冗長な GetPR 呼び出しを削除し j.PR を使用 (#82)

### DIFF
--- a/backend/internal/infra/job/worker.go
+++ b/backend/internal/infra/job/worker.go
@@ -157,12 +157,8 @@ func (w *Worker) process(ctx context.Context, item Item) {
 
 	tStart := time.Now()
 
-	prInfo, err := w.prRepo.GetPR(ctx, item.Token, j.PR.Owner, j.PR.Repo, j.PR.Number)
-	if err != nil {
-		fail(fmt.Errorf("get PR: %w", err))
-		return
-	}
-
+	// PR のメタ情報（Title / refs / SHA）は usecase.Execute が GetPR で解決済みで
+	// jobs テーブルに永続化されているため、ここで再取得はせず j.PR をそのまま使う。
 	t0 := time.Now()
 	changed, err := w.prRepo.ListChangedGoFiles(ctx, item.Token, j.PR.Owner, j.PR.Repo, j.PR.Number)
 	if err != nil {
@@ -177,7 +173,7 @@ func (w *Worker) process(ctx context.Context, item Item) {
 	onBuild := func() { buildOnce.Do(func() { setPhase(domain.JobPhaseBuildGraph) }) }
 
 	t1 := time.Now()
-	headGraph, baseGraph, cleanups, err := w.buildBothGraphs(ctx, *prInfo, item.Token, changed, onBuild)
+	headGraph, baseGraph, cleanups, err := w.buildBothGraphs(ctx, j.PR, item.Token, changed, onBuild)
 	defer func() {
 		for _, c := range cleanups {
 			if c != nil {
@@ -217,7 +213,7 @@ func (w *Worker) process(ctx context.Context, item Item) {
 
 	setPhase(domain.JobPhaseVisualize)
 	t4 := time.Now()
-	diffFiles, err := analyzer.CollectDiffFiles(ctx, w.prRepo, item.Token, *prInfo, changed)
+	diffFiles, err := analyzer.CollectDiffFiles(ctx, w.prRepo, item.Token, j.PR, changed)
 	if err != nil {
 		log.Printf("worker: CollectDiffFiles error (non-fatal): %v", err)
 		diffFiles = nil
@@ -228,7 +224,7 @@ func (w *Worker) process(ctx context.Context, item Item) {
 	analysisID := domain.AnalysisID(w.newID())
 	a := &domain.Analysis{
 		ID:           analysisID,
-		PR:           *prInfo,
+		PR:           j.PR,
 		Result:       result,
 		ChangedFiles: diffFiles,
 		CreatedAt:    w.now().UTC(),

--- a/backend/internal/infra/job/worker_test.go
+++ b/backend/internal/infra/job/worker_test.go
@@ -170,7 +170,6 @@ func newWorkerWithFakes(
 // --- tests ---
 
 func TestWorker_HappyPath(t *testing.T) {
-	prInfo := &domain.PRInfo{Owner: "o", Repo: "r", Number: 1, HeadSHA: "head-sha", BaseSHA: "base-sha"}
 	graph := &domain.Graph{
 		Nodes: []domain.Node{{ID: "fn:A", Name: "A"}},
 	}
@@ -183,7 +182,8 @@ func TestWorker_HappyPath(t *testing.T) {
 	jobs.jobs["job-1"] = &domain.Job{
 		ID:     "job-1",
 		Status: domain.JobStatusPending,
-		PR:     domain.PRInfo{Owner: "o", Repo: "r", Number: 1},
+		// usecase.Execute が GetPR で解決した PR（SHA 込み）を永続化した状態を模す。
+		PR: domain.PRInfo{Owner: "o", Repo: "r", Number: 1, HeadSHA: "head-sha", BaseSHA: "base-sha"},
 	}
 	analyses := &fakeAnalysisRepo{}
 
@@ -196,7 +196,8 @@ func TestWorker_HappyPath(t *testing.T) {
 	w := newWorkerWithFakes(
 		jobs,
 		analyses,
-		&fakePRRepo{prInfo: prInfo, changed: []domain.ChangedFile{}},
+		// GetPR は worker から呼ばれない（j.PR を使う）ため prInfo は設定しない。
+		&fakePRRepo{changed: []domain.ChangedFile{}},
 		st,
 		&fakeCGBuilder{graph: graph},
 		&fakeClusterer{result: result},
@@ -248,7 +249,6 @@ func TestWorker_HappyPath(t *testing.T) {
 }
 
 func TestWorker_BaseSHA_RenameNormalized(t *testing.T) {
-	prInfo := &domain.PRInfo{Owner: "o", Repo: "r", Number: 1, HeadSHA: "head", BaseSHA: "base"}
 	graph := &domain.Graph{}
 	result := &domain.ClusterResult{Graph: *graph}
 
@@ -256,7 +256,7 @@ func TestWorker_BaseSHA_RenameNormalized(t *testing.T) {
 	jobs.jobs["job-r"] = &domain.Job{
 		ID:     "job-r",
 		Status: domain.JobStatusPending,
-		PR:     domain.PRInfo{Owner: "o", Repo: "r", Number: 1},
+		PR:     domain.PRInfo{Owner: "o", Repo: "r", Number: 1, HeadSHA: "head", BaseSHA: "base"},
 	}
 	analyses := &fakeAnalysisRepo{}
 
@@ -270,7 +270,7 @@ func TestWorker_BaseSHA_RenameNormalized(t *testing.T) {
 
 	w := newWorkerWithFakes(
 		jobs, analyses,
-		&fakePRRepo{prInfo: prInfo, changed: changed},
+		&fakePRRepo{changed: changed},
 		st,
 		&fakeCGBuilder{graph: graph},
 		&fakeClusterer{result: result},
@@ -361,18 +361,17 @@ func (s *blockingSourceTree) PrepareAtSHA(ctx context.Context, _ domain.PRInfo, 
 }
 
 func TestWorker_JobTimeout_MarksError(t *testing.T) {
-	prInfo := &domain.PRInfo{Owner: "o", Repo: "r", Number: 1, HeadSHA: "h", BaseSHA: "b"}
 	jobs := newFakeJobStore()
 	jobs.jobs["job-t"] = &domain.Job{
 		ID:     "job-t",
 		Status: domain.JobStatusPending,
-		PR:     domain.PRInfo{Owner: "o", Repo: "r", Number: 1},
+		PR:     domain.PRInfo{Owner: "o", Repo: "r", Number: 1, HeadSHA: "h", BaseSHA: "b"},
 	}
 	analyses := &fakeAnalysisRepo{}
 
 	q := NewQueue(1)
 	w := NewWorker(q, jobs, analyses,
-		&fakePRRepo{prInfo: prInfo, changed: []domain.ChangedFile{}},
+		&fakePRRepo{changed: []domain.ChangedFile{}},
 		&blockingSourceTree{},
 		&fakeCGBuilder{graph: &domain.Graph{}},
 		&fakeClusterer{result: &domain.ClusterResult{}},


### PR DESCRIPTION
親: #82 / #79

## 背景

`worker.process` の冒頭で `w.prRepo.GetPR(...)` を呼び、PR のメタ情報（Title / base・head の ref / SHA）を GitHub API から取得していた。しかしこの情報は `usecase.Execute` がジョブ enqueue 前に `GetPR` で解決して `jobs` テーブルへ永続化しており（`analyze_pr.go`）、worker が `FindByID` で読み込む `j.PR` にすべて含まれている（`store/job_repo.go` が全フィールドを保存・復元）。worker 側の `GetPR` は同じ情報の冗長な API 往復だった。

## 施策

- `worker.process` 冒頭の `GetPR` 呼び出しを削除し、`buildBothGraphs` / `CollectDiffFiles` / 保存する `Analysis.PR` を `j.PR` に置き換え
- 解析対象の SHA が「Execute がキャッシュキーに使った SHA」と必ず一致するようになり、キャッシュ判定と解析の一貫性も向上
- worker テストを更新: `GetPR` は worker から呼ばれなくなったため、解決済み PR（SHA 込み）を Job 側に持たせ、`prepareAtSHA` に渡る base SHA が `j.PR` 由来であることを検証

## 確認

- `gofmt -w . && go vet ./...` → clean
- `go test ./...` → 全パッケージ pass（job / usecase の更新テスト含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)