### PR TITLE
perf: レスポンス gzip 圧縮 + 解析結果への Cache-Control 付与 (#93一部)

### DIFF
--- a/backend/internal/api/analysis_handler.go
+++ b/backend/internal/api/analysis_handler.go
@@ -15,6 +15,11 @@ import (
 	"github.com/s-sh1m0/u-22_procon/backend/internal/usecase"
 )
 
+// snapshotCacheControl は jobId 単位で不変な解析結果（グラフ / diff）に付ける
+// Cache-Control。jobId は特定コミットのスナップショットで内容が変わらないため、
+// クライアント側で長めにキャッシュしてよい。private はユーザー個別の認証済み応答のため。
+const snapshotCacheControl = "private, max-age=86400"
+
 // analyzeUseCase は AnalysisHandler が使うユースケースインターフェース。
 type analyzeUseCase interface {
 	Execute(ctx context.Context, token string, pr domain.PRInfo) (domain.JobID, error)
@@ -99,6 +104,7 @@ func (h *AnalysisHandler) GetGraph(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("get graph: %v", err))
 	}
 
+	c.Response().Header().Set("Cache-Control", snapshotCacheControl)
 	return c.JSON(http.StatusOK, toGraphResponse(analysis))
 }
 

--- a/backend/internal/api/analysis_handler_test.go
+++ b/backend/internal/api/analysis_handler_test.go
@@ -205,6 +205,10 @@ func TestGetGraph_Success(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected 200, got %d", rec.Code)
 	}
+	// jobId 単位で不変なスナップショットなので Cache-Control が付く。
+	if got := rec.Header().Get("Cache-Control"); got != snapshotCacheControl {
+		t.Errorf("Cache-Control=%q want %q", got, snapshotCacheControl)
+	}
 	var resp GraphResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("unmarshal: %v", err)
@@ -341,5 +345,9 @@ func TestGetGraph_NotReady(t *testing.T) {
 	err := h.GetGraph(c)
 	if he, ok := err.(*echo.HTTPError); !ok || he.Code != http.StatusConflict {
 		t.Errorf("expected 409, got %v", err)
+	}
+	// まだ done でない応答はキャッシュさせない。
+	if got := rec.Header().Get("Cache-Control"); got != "" {
+		t.Errorf("Cache-Control should be unset on not-ready, got %q", got)
 	}
 }

--- a/backend/internal/api/diff_handler.go
+++ b/backend/internal/api/diff_handler.go
@@ -39,5 +39,6 @@ func (h *DiffHandler) Get(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("get diff: %v", err))
 	}
 
+	c.Response().Header().Set("Cache-Control", snapshotCacheControl)
 	return c.JSON(http.StatusOK, toDiffResponse(analysis))
 }

--- a/backend/internal/api/diff_handler_test.go
+++ b/backend/internal/api/diff_handler_test.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
+	"github.com/s-sh1m0/u-22_procon/backend/internal/usecase"
+)
+
+func TestDiffGet_Success(t *testing.T) {
+	analysis := &domain.Analysis{
+		ID: "a1",
+		ChangedFiles: []domain.DiffFile{
+			{Filename: "pkg/a.go", Status: domain.FileStatusAdded, Additions: 3},
+		},
+	}
+	h := NewDiffHandler(&fakeReadUC{analysis: analysis})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/diff/job-1", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("jobId")
+	c.SetParamValues("job-1")
+
+	if err := h.Get(c); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	// jobId 単位で不変なスナップショットなので Cache-Control が付く。
+	if got := rec.Header().Get("Cache-Control"); got != snapshotCacheControl {
+		t.Errorf("Cache-Control=%q want %q", got, snapshotCacheControl)
+	}
+	var resp DiffResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Files) != 1 || resp.Files[0].Filename != "pkg/a.go" {
+		t.Errorf("unexpected files: %+v", resp.Files)
+	}
+}
+
+func TestDiffGet_NotReady(t *testing.T) {
+	h := NewDiffHandler(&fakeReadUC{graphErr: usecase.ErrJobNotReady})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/diff/pending-job", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("jobId")
+	c.SetParamValues("pending-job")
+
+	err := h.Get(c)
+	if he, ok := err.(*echo.HTTPError); !ok || he.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %v", err)
+	}
+	// まだ done でない応答はキャッシュさせない。
+	if got := rec.Header().Get("Cache-Control"); got != "" {
+		t.Errorf("Cache-Control should be unset on not-ready, got %q", got)
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -30,6 +30,9 @@ func NewRouter(
 		},
 	}))
 	e.Use(middleware.Recover())
+	// レスポンス gzip 圧縮。グラフ / diff の JSON は ID の反復が多く圧縮率が高い。
+	// MinLength 未満（ジョブ状態ポーリング等の小さな応答）は圧縮せず CPU を無駄にしない。
+	e.Use(middleware.GzipWithConfig(middleware.GzipConfig{MinLength: 1024}))
 
 	auth := e.Group("/auth")
 	auth.GET("/github", authHandler.Login)


### PR DESCRIPTION
親: #93 / #79

#93 のうち **gzip 圧縮 + Cache-Control** 部分のみを実装する。`changed_files` のカラム分離（読み出し経路からの diff 本文 unmarshal 除去 = PR-H）は別 PR に切り出す。

## 背景

- レスポンスに gzip 圧縮がなく、グラフ / diff の JSON をそのまま転送していた。これらは関数 ID・ノード ID の反復が多く圧縮率が高い。
- `/api/graph`・`/api/diff` の結果は jobId（特定コミットのスナップショット）単位で不変だが Cache-Control がなく、画面遷移やクラスタモード切替のたびに毎回フルで取得していた。

## 施策

- echo に `middleware.GzipWithConfig(MinLength: 1024)` を追加。ジョブ状態ポーリング等の小さな応答は圧縮せず CPU を浪費しない
- `/api/graph`・`/api/diff` の **成功応答のみ** に `Cache-Control: private, max-age=86400`
  - jobId は不変スナップショットのため長めのキャッシュが安全。クラスタモードは `?cluster=` として URL に含まれるためキャッシュはモード別に分かれる
  - `private` はユーザー個別の認証済み応答のため
  - 404（not found）/ 409（not ready）にはヘッダを付けず、まだ done でない応答をキャッシュさせない

## 確認

- `gofmt -w . && go vet ./...` → clean
- `go test ./...` → 全パッケージ pass
  - `TestGetGraph_Success` / 新規 `TestDiffGet_Success` で成功応答に Cache-Control が付くこと
  - `TestGetGraph_NotReady` / 新規 `TestDiffGet_NotReady` で未完了応答にヘッダが付かないこと
- gzip の実サイズ比較（代表 PR で `curl -H 'Accept-Encoding: gzip' --compressed` の転送量）は dev で確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)