### PR TITLE
perf: 解析の依存を export data 化しソース型チェック/SSA を削減 (#82)

### DIFF
--- a/backend/internal/infra/analyzer/callgraph.go
+++ b/backend/internal/infra/analyzer/callgraph.go
@@ -56,8 +56,9 @@ func (b *GoCallGraphBuilder) Build(_ context.Context, pkgs []*packages.Package, 
 	}
 
 	// 1. プロジェクト内パッケージのみを抽出する。
-	// NeedDeps によって pkgs には外部ライブラリも含まれるが、SSA 構築と
-	// loadedSet はプロジェクト内パッケージのみを対象にする。
+	// pkgs に外部ライブラリが含まれることがあるが（NeedDeps 有効時、または
+	// 変更パッケージ自体が依存として現れる場合）、SSA 構築と loadedSet は
+	// プロジェクト内パッケージのみを対象にする。
 	// pkg.Module.Main が true のパッケージが自リポジトリのパッケージ。
 	projectPkgs := make([]*packages.Package, 0, len(pkgs))
 	for _, pkg := range pkgs {
@@ -66,9 +67,18 @@ func (b *GoCallGraphBuilder) Build(_ context.Context, pkgs []*packages.Package, 
 		}
 	}
 
-	// 2. SSA プログラムを構築（プロジェクト内パッケージのみ）
+	// 2. SSA プログラムを構築（プロジェクト内パッケージのみ）。
+	// ssautil.Packages は projectPkgs の関数本体のみ SSA 化し、依存パッケージの
+	// 本体は構築しない。CHA が対象にするのは本体を持つ関数だが、出力グラフは
+	// isInLoadedSet でプロジェクト内→内のエッジに限定するため、依存本体が無くても
+	// 結果は変わらない。escape hatch が立つときのみ依存も含む AllPackages を使う。
 	tSSA := time.Now()
-	prog, _ := ssautil.AllPackages(projectPkgs, ssa.InstantiateGenerics)
+	var prog *ssa.Program
+	if sourceDepsEnabled() {
+		prog, _ = ssautil.AllPackages(projectPkgs, ssa.InstantiateGenerics)
+	} else {
+		prog, _ = ssautil.Packages(projectPkgs, ssa.InstantiateGenerics)
+	}
 	prog.Build()
 	ssaTook := time.Since(tSSA)
 

--- a/backend/internal/infra/analyzer/callgraph_test.go
+++ b/backend/internal/infra/analyzer/callgraph_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -284,6 +285,113 @@ func TestGoCallGraphBuilder_Build_SameMethodNameNotCollided(t *testing.T) {
 		if !found {
 			t.Errorf("edge %s->C not found (edges: %v)", mID, graph.Edges)
 		}
+	}
+}
+
+// setupCGFixtureExtDep は外部依存（stdlib）を含む Go モジュールを構築する。
+// export data 経路（NeedDeps なし + ssautil.Packages）で外部パッケージの本体 SSA を
+// 構築しなくても、プロジェクト内グラフが旧経路と一致することを検証するための fixture。
+//
+//	example.com/extfixture
+//	  pkg/a/a.go -- func A() string { return strings.ToUpper(b.B()) }  ← 外部(strings)+内部(b.B)呼び出し
+//	  pkg/b/b.go -- func B() string { return strings.TrimSpace("x") }  ← 外部(strings)呼び出し
+func setupCGFixtureExtDep(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	writeFile := func(rel, content string) {
+		t.Helper()
+		abs := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	writeFile("go.mod", "module example.com/extfixture\n\ngo 1.21\n")
+	writeFile("pkg/a/a.go", `package a
+
+import (
+	"strings"
+
+	"example.com/extfixture/pkg/b"
+)
+
+func A() string { return strings.ToUpper(b.B()) }
+`)
+	writeFile("pkg/b/b.go", `package b
+
+import "strings"
+
+func B() string { return strings.TrimSpace(" x ") }
+`)
+	return dir
+}
+
+// TestGoCallGraphBuilder_Build_ExportDataParity は PR-F（依存を export data 化）の
+// 計測ゲートに相当する回帰テスト。外部依存を持つ fixture を、
+//   - 既定（loadMode に NeedDeps なし + ssautil.Packages）
+//   - escape hatch（ANALYZER_SOURCE_DEPS=1 → NeedDeps + ssautil.AllPackages）
+//
+// の両経路で本番ローダ経由でロード→ Build し、プロジェクト内グラフのノード集合・
+// エッジ集合が完全一致することを確認する。依存の SSA 本体を構築しなくても出力が
+// 変わらないという PR-F の前提を CI で守る。
+func TestGoCallGraphBuilder_Build_ExportDataParity(t *testing.T) {
+	root := setupCGFixtureExtDep(t)
+	changedPkgs := []string{
+		"example.com/extfixture/pkg/a",
+		"example.com/extfixture/pkg/b",
+	}
+	changedFiles := []string{
+		filepath.Join(root, "pkg/a/a.go"),
+		filepath.Join(root, "pkg/b/b.go"),
+	}
+
+	build := func(sourceDeps bool) (map[string]struct{}, map[[2]string]struct{}) {
+		if sourceDeps {
+			t.Setenv("ANALYZER_SOURCE_DEPS", "1")
+		} else {
+			t.Setenv("ANALYZER_SOURCE_DEPS", "0")
+		}
+
+		res, err := NewGoPackageLoader().Load(context.Background(), root, changedPkgs)
+		if err != nil {
+			t.Fatalf("Load(sourceDeps=%v): %v", sourceDeps, err)
+		}
+		b := &GoCallGraphBuilder{MaxDepth: 3}
+		g, err := b.Build(context.Background(), res.Packages, changedPkgs, changedFiles, root)
+		if err != nil {
+			t.Fatalf("Build(sourceDeps=%v): %v", sourceDeps, err)
+		}
+
+		nodes := make(map[string]struct{}, len(g.Nodes))
+		for _, n := range g.Nodes {
+			// stdlib のパッケージがグラフに漏れていないことも同時に確認する。
+			if n.Package == "strings" || n.Package == "fmt" || n.Package == "runtime" {
+				t.Errorf("stdlib package %q leaked into graph (node %q, sourceDeps=%v)", n.Package, n.Name, sourceDeps)
+			}
+			nodes[string(n.ID)] = struct{}{}
+		}
+		edges := make(map[[2]string]struct{}, len(g.Edges))
+		for _, e := range g.Edges {
+			edges[[2]string{string(e.From), string(e.To)}] = struct{}{}
+		}
+		return nodes, edges
+	}
+
+	fastNodes, fastEdges := build(false)
+	slowNodes, slowEdges := build(true)
+
+	if len(fastNodes) == 0 {
+		t.Fatal("expected non-empty graph on export-data path")
+	}
+	if !reflect.DeepEqual(fastNodes, slowNodes) {
+		t.Errorf("node sets diverge between export-data and source-deps paths:\n export-data=%v\n source-deps=%v", fastNodes, slowNodes)
+	}
+	if !reflect.DeepEqual(fastEdges, slowEdges) {
+		t.Errorf("edge sets diverge between export-data and source-deps paths:\n export-data=%v\n source-deps=%v", fastEdges, slowEdges)
 	}
 }
 

--- a/backend/internal/infra/analyzer/parser.go
+++ b/backend/internal/infra/analyzer/parser.go
@@ -41,16 +41,33 @@ var ErrRepositoryTooLarge = errors.New("analyzer: repository is too large to ana
 const maxFastLoadPackages = 1500
 
 // loadMode は callgraph (#5) と diff→AST マップ (#6) で必要なフラグを全て含む。
+//
+// NeedDeps は含めない。含めると要求パッケージの推移依存閉包全体をソースから
+// 型チェックしてしまい、巨大リポジトリで解析が遅く・メモリ消費が大きくなる。
+// 依存の型情報はビルドキャッシュ由来の export data から取得され（NeedTypes が
+// あれば go/packages が自動で読む）、プロジェクト内パッケージの型チェックには
+// これで十分。出力するコールグラフはプロジェクト内→内のエッジのみで、依存の
+// 関数本体（SSA）は元々除外しているため、export data 化しても結果は変わらない。
+// 旧挙動（依存をソースから型チェック）に戻したいときは環境変数
+// ANALYZER_SOURCE_DEPS=1 を設定する（sourceDepsEnabled を参照）。
 const loadMode = packages.NeedName |
 	packages.NeedFiles |
 	packages.NeedCompiledGoFiles |
 	packages.NeedImports |
-	packages.NeedDeps |
 	packages.NeedSyntax |
 	packages.NeedTypes |
 	packages.NeedTypesInfo |
 	packages.NeedTypesSizes |
 	packages.NeedModule
+
+// sourceDepsEnabled は依存パッケージをソースから型チェック・SSA 構築する
+// 旧挙動（NeedDeps + ssautil.AllPackages）を使うかを返す。
+// 既定は false（依存は export data から型のみ取得し、SSA はプロジェクト内
+// パッケージのみ構築する高速経路）。ANALYZER_SOURCE_DEPS=1 で旧挙動に戻せる
+// escape hatch。export data 経路で結果不整合が疑われたときの切り戻し用。
+func sourceDepsEnabled() bool {
+	return os.Getenv("ANALYZER_SOURCE_DEPS") == "1"
+}
 
 // fastLoadMode は型チェックなしでパッケージ構造だけを取得する高速フラグ。
 // NeedImports まで含めることで import グラフから近傍パッケージを特定できる。
@@ -204,8 +221,14 @@ func (l *GoPackageLoader) Load(ctx context.Context, rootDir string, patterns []s
 		return &LoadResult{}, nil
 	}
 
+	mode := loadMode
+	if sourceDepsEnabled() {
+		// escape hatch: 依存も含めてソースから型チェックする旧挙動に戻す。
+		mode |= packages.NeedDeps
+	}
+
 	cfg := &packages.Config{
-		Mode:    loadMode,
+		Mode:    mode,
 		Dir:     rootDir,
 		Context: ctx,
 		Tests:   false,


### PR DESCRIPTION
## 概要

PR-F（perf ロードマップ #79/#82 の最大レバー）。巨大 Go リポジトリで解析が遅く・メモリ消費が大きい原因である「依存パッケージの推移閉包をソースから型チェック + SSA 構築」を止める。

- `parser.go` の `loadMode` から `packages.NeedDeps` を除去。依存パッケージの型情報は go/packages が export data（ビルドキャッシュ由来）から取得する。前提のビルドキャッシュ named volume 化は PR #100 でマージ済み。
- `callgraph.go` の SSA 構築を `ssautil.AllPackages` → `ssautil.Packages` に変更。依存パッケージの関数本体 SSA 構築が消える。

## なぜ結果が変わらないか

出力するコールグラフは `isInLoadedSet` でプロジェクト内 → 内のエッジに限定しており、依存パッケージの関数本体はもともとグラフから除外している。CHA のインターフェースディスパッチもプロジェクト内の実装型は SSA に含まれるため、内→内のエッジは保存される。よって依存を export data 化しても出力グラフは原理上不変。

## Escape hatch

結果不整合が疑われたときの切り戻し用に、環境変数 `ANALYZER_SOURCE_DEPS=1` で旧挙動（`NeedDeps` + `ssautil.AllPackages`）に戻せる。

## Test plan

- [x] `gofmt` / `go vet` グリーン
- [x] `docker compose run --build --rm backend go test ./...` グリーン
- [x] 追加した回帰テスト `TestGoCallGraphBuilder_Build_ExportDataParity`：外部依存(stdlib)を含む fixture を本番ローダ経由で両経路（default / `ANALYZER_SOURCE_DEPS=1`）ロード→Build し、**ノード集合・エッジ集合の完全一致**を検証（stdlib ノードの非漏洩も同時確認）
- [ ] **計測ゲート（要 PAT・レビュアー実施）**: `cmd/bench -both` で代表 3 リポジトリ（小 / 中 / 上限近く）の新旧 A/B を計測し、**ノード数・エッジ数が完全一致**することを確認したうえで所要時間・ピークメモリの改善幅を記録する。CLI 環境では GitHub 認証と clone が必要なため未実施