### PR TITLE
perf: base/head の clone を worktree 共有で 1 fetch に集約 (PR-G, #82)

### DIFF
--- a/backend/cmd/bench/main.go
+++ b/backend/cmd/bench/main.go
@@ -125,33 +125,42 @@ func runHeadOnly(ctx context.Context, prInfo domain.PRInfo, token string, change
 // 検出 → Cluster）を実行し、ノード/エッジ数のサマリを出力する。
 // PR-F（依存の export data 化 / #82）の A/B 比較ゲートとして、新旧実装で
 // このサマリのノード/エッジ数が完全一致することの確認に使う。
-// エラー時も defer した Cleanup（base/head 2つの一時ディレクトリ）が走るよう、
+// エラー時も defer した Cleanup（base/head 共有の一時ディレクトリ）が走るよう、
 // log.Fatalf せず error を返す。
 func runBoth(ctx context.Context, prInfo domain.PRInfo, token string, changed []domain.ChangedFile) error {
 	sourceTree := analyzer.NewSourceTree(analyzer.NewGitCloner(), analyzer.NewGoPackageLoader())
 	cgBuilder := analyzer.NewGoCallGraphBuilder()
 
-	// 3. base+head を並列構築（worker.buildBothGraphs と同じ構成）
+	// 3. base+head を並列構築（worker.buildBothGraphs と同じ構成）。
+	// clone は CloneBoth で1リポジトリ共有（1回の fetch）にまとめる。
 	t0 := time.Now()
 	var headGraph, baseGraph *domain.Graph
-	cleanups := make([]func() error, 2)
-	defer func() {
-		for _, c := range cleanups {
-			if c != nil {
-				_ = c()
-			}
-		}
-	}()
+
+	tc := time.Now()
+	cw, err := sourceTree.CloneBoth(ctx, prInfo, token)
+	if err != nil {
+		return fmt.Errorf("clone base/head: %w", err)
+	}
+	defer func() { _ = cw.Cleanup() }()
+	log.Printf("[3a] CloneBoth (shared clone) took %s", time.Since(tc))
+
+	headDir, ok := cw.Dirs[prInfo.HeadSHA]
+	if !ok {
+		return fmt.Errorf("clone base/head: missing worktree for head %s", prInfo.HeadSHA)
+	}
+	baseDir, ok := cw.Dirs[prInfo.BaseSHA]
+	if !ok {
+		return fmt.Errorf("clone base/head: missing worktree for base %s", prInfo.BaseSHA)
+	}
 
 	eg, egCtx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
 		t := time.Now()
-		prepared, err := sourceTree.Prepare(egCtx, prInfo, token, changed)
+		prepared, err := sourceTree.PrepareFromDir(egCtx, headDir, changed)
 		if err != nil {
 			return fmt.Errorf("head prepare: %w", err)
 		}
-		cleanups[0] = prepared.Cleanup
-		log.Printf("[head] Prepare took %s (pkgs=%d, changed pkgs=%d)", time.Since(t), len(prepared.Packages), len(prepared.ChangedPackages))
+		log.Printf("[head] PrepareFromDir took %s (pkgs=%d, changed pkgs=%d)", time.Since(t), len(prepared.Packages), len(prepared.ChangedPackages))
 		t = time.Now()
 		g, err := cgBuilder.Build(egCtx, prepared.Packages, prepared.ChangedPackages, prepared.ChangedFileAbsPaths, prepared.RepoRoot)
 		if err != nil {
@@ -164,12 +173,11 @@ func runBoth(ctx context.Context, prInfo domain.PRInfo, token string, changed []
 	eg.Go(func() error {
 		t := time.Now()
 		baseChanged := domain.NormalizeChangedForBase(changed)
-		prepared, err := sourceTree.PrepareAtSHA(egCtx, prInfo, token, prInfo.BaseSHA, baseChanged)
+		prepared, err := sourceTree.PrepareFromDir(egCtx, baseDir, baseChanged)
 		if err != nil {
 			return fmt.Errorf("base prepare: %w", err)
 		}
-		cleanups[1] = prepared.Cleanup
-		log.Printf("[base] Prepare took %s (pkgs=%d, changed pkgs=%d)", time.Since(t), len(prepared.Packages), len(prepared.ChangedPackages))
+		log.Printf("[base] PrepareFromDir took %s (pkgs=%d, changed pkgs=%d)", time.Since(t), len(prepared.Packages), len(prepared.ChangedPackages))
 		t = time.Now()
 		g, err := cgBuilder.Build(egCtx, prepared.Packages, prepared.ChangedPackages, prepared.ChangedFileAbsPaths, prepared.RepoRoot)
 		if err != nil {

--- a/backend/internal/infra/analyzer/clone.go
+++ b/backend/internal/infra/analyzer/clone.go
@@ -26,9 +26,28 @@ type ClonedRepo struct {
 	Cleanup func() error // 解析完了後にdeferで呼ぶ
 }
 
+// WorktreesRequest は複数SHAを1つのオブジェクトストア共有でcloneするためのパラメータ。
+type WorktreesRequest struct {
+	Owner, Repo string
+	Token       string   // 空文字 = anonymous（公開リポジトリ）
+	SHAs        []string // clone対象のSHA群（重複は許容・内部でdedupされる）
+}
+
+// ClonedWorktrees は1リポジトリを共有しSHAごとにworktreeを持つclone結果。
+type ClonedWorktrees struct {
+	// Dirs はリクエストした各SHA → そのworktreeの絶対パス（EvalSymlinks済み）。
+	// 同一SHAを重複指定した場合は同じパスにマップされる。
+	Dirs    map[string]string
+	Cleanup func() error // 解析完了後にdeferで呼ぶ（共有tmp dirを丸ごと削除する）
+}
+
 // Cloner はリモートGitHubリポジトリを特定SHAで浅くcloneする抽象。
 type Cloner interface {
 	Clone(ctx context.Context, req CloneRequest) (*ClonedRepo, error)
+	// CloneWorktrees は複数SHAを1回のfetchで取得し、SHAごとにworktreeを作る。
+	// base/headを別々にcloneするより、オブジェクトストアとfetchを共有できる
+	// （変更のないblobは1度しか取得しない）。
+	CloneWorktrees(ctx context.Context, req WorktreesRequest) (*ClonedWorktrees, error)
 }
 
 // GitCloner はexec.Command("git", ...)でCloneを実装する本番実装。
@@ -111,6 +130,120 @@ func (c *GitCloner) Clone(ctx context.Context, req CloneRequest) (*ClonedRepo, e
 		RootDir: resolved,
 		Cleanup: cleanup,
 	}, nil
+}
+
+// CloneWorktrees は req.SHAs を1つの共有リポジトリに1回の fetch で取得し、
+// SHAごとに作業ツリー（worktree）を生やす。先頭SHAは共有リポジトリ自身を
+// 作業ツリーとして使い、残りは git worktree で追加する。すべてのworktreeが
+// 同一オブジェクトストアを共有するため、base/head間で共通のblobは1度しか
+// fetchされない（--filter=blob:none の遅延取得がストアを共有して効く）。
+// cleanupは共有tmp dirのRemoveAllで完結する。
+func (c *GitCloner) CloneWorktrees(ctx context.Context, req WorktreesRequest) (*ClonedWorktrees, error) {
+	if len(req.SHAs) == 0 {
+		return nil, fmt.Errorf("%w: no SHAs given", ErrCloneFailed)
+	}
+	gitBin := c.GitBin
+	if gitBin == "" {
+		gitBin = "git"
+	}
+	tmpDir := c.TmpDir
+	if tmpDir == "" {
+		tmpDir = os.TempDir()
+	}
+
+	parent, err := os.MkdirTemp(tmpDir, "reviewarena-clone-*")
+	if err != nil {
+		return nil, fmt.Errorf("analyzer: create tempdir: %w", err)
+	}
+	cleanup := func() error {
+		err := os.RemoveAll(parent)
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+
+	// 共有オブジェクトストアとなるリポジトリ。ここに全SHAをまとめてfetchし、
+	// SHAごとにworktreeを生やすことでclone/fetchを1回に集約する。
+	repoDir := filepath.Join(parent, "repo")
+	if err := os.Mkdir(repoDir, 0o755); err != nil {
+		_ = cleanup()
+		return nil, fmt.Errorf("analyzer: create repo dir: %w", err)
+	}
+	if err := c.runGit(ctx, gitBin, repoDir, "init"); err != nil {
+		_ = cleanup()
+		return nil, err
+	}
+
+	// token がある場合はURL認証を使う（Cloneと同様、一時ディレクトリ内で完結し
+	// ClonedWorktrees.Cleanup() で削除されるため安全）。
+	var remoteURL string
+	if req.Token != "" {
+		remoteURL = fmt.Sprintf("https://oauth2:%s@github.com/%s/%s.git", req.Token, req.Owner, req.Repo)
+	} else {
+		remoteURL = fmt.Sprintf("https://github.com/%s/%s.git", req.Owner, req.Repo)
+	}
+	if err := c.runGit(ctx, gitBin, repoDir, "remote", "add", "origin", remoteURL); err != nil {
+		_ = cleanup()
+		return nil, err
+	}
+
+	// 重複を除いたSHA群を1回のfetchでまとめて取得する。
+	uniqueSHAs := dedupStrings(req.SHAs)
+	fetchArgs := append([]string{"fetch", "--depth=1", "--no-tags", "--filter=blob:none", "origin"}, uniqueSHAs...)
+	if err := c.runGit(ctx, gitBin, repoDir, fetchArgs...); err != nil {
+		_ = cleanup()
+		return nil, err
+	}
+
+	// SHA → worktree絶対パス。先頭SHAはrepoDirを作業ツリーとして使い、
+	// 残りは git worktree add で追加する（すべてrepoDirのオブジェクトを共有）。
+	shaToDir := make(map[string]string, len(uniqueSHAs))
+	for i, sha := range uniqueSHAs {
+		var wtDir string
+		if i == 0 {
+			if err := c.runGit(ctx, gitBin, repoDir, "checkout", "--detach", sha); err != nil {
+				_ = cleanup()
+				return nil, err
+			}
+			wtDir = repoDir
+		} else {
+			wtDir = filepath.Join(parent, fmt.Sprintf("wt-%d", i))
+			if err := c.runGit(ctx, gitBin, repoDir, "worktree", "add", "--detach", wtDir, sha); err != nil {
+				_ = cleanup()
+				return nil, err
+			}
+		}
+		// EvalSymlinksでシンボリックリンクを解決しておく（macOS /tmp が /private/tmp になるケースなど）
+		resolved, err := filepath.EvalSymlinks(wtDir)
+		if err != nil {
+			_ = cleanup()
+			return nil, fmt.Errorf("analyzer: eval symlinks %s: %w", wtDir, err)
+		}
+		shaToDir[sha] = resolved
+	}
+
+	// リクエストされた各SHA（重複含む）を対応するworktreeパスに紐付ける。
+	dirs := make(map[string]string, len(req.SHAs))
+	for _, sha := range req.SHAs {
+		dirs[sha] = shaToDir[sha]
+	}
+
+	return &ClonedWorktrees{Dirs: dirs, Cleanup: cleanup}, nil
+}
+
+// dedupStrings は順序を保ったまま重複を除いたスライスを返す。
+func dedupStrings(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
 }
 
 func (c *GitCloner) runGit(ctx context.Context, gitBin, dir string, args ...string) error {

--- a/backend/internal/infra/analyzer/clone_test.go
+++ b/backend/internal/infra/analyzer/clone_test.go
@@ -103,6 +103,152 @@ func TestGitCloner_Clone_Local(t *testing.T) {
 	}
 }
 
+// setupLocalBareRepoTwoCommits は bare リポジトリに2コミットを push し、
+// それぞれの SHA を返す。commit1 は main.go のみ、commit2 は foo.go を追加する。
+// CloneWorktrees の「1リポジトリ共有 + SHAごと worktree」の検証に使う。
+func setupLocalBareRepoTwoCommits(t *testing.T) (bareURL, sha1, sha2 string) {
+	t.Helper()
+
+	bareDir := t.TempDir()
+	if err := exec.Command("git", "init", "--bare", bareDir).Run(); err != nil {
+		t.Fatalf("git init --bare: %v", err)
+	}
+
+	workDir := t.TempDir()
+	runIn := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+		}
+	}
+	revParse := func(dir string) string {
+		t.Helper()
+		out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+		if err != nil {
+			t.Fatalf("rev-parse: %v", err)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	runIn(workDir, "init")
+	runIn(workDir, "config", "user.email", "test@example.com")
+	runIn(workDir, "config", "user.name", "Test")
+
+	if err := os.WriteFile(filepath.Join(workDir, "go.mod"), []byte("module example.com/test\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runIn(workDir, "add", ".")
+	runIn(workDir, "commit", "-m", "commit1")
+	sha1 = revParse(workDir)
+
+	if err := os.WriteFile(filepath.Join(workDir, "foo.go"), []byte("package main\n\nfunc Foo() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runIn(workDir, "add", ".")
+	runIn(workDir, "commit", "-m", "commit2")
+	sha2 = revParse(workDir)
+
+	runIn(workDir, "remote", "add", "origin", bareDir)
+	runIn(workDir, "push", "origin", "HEAD:refs/heads/main")
+
+	return "file://" + bareDir, sha1, sha2
+}
+
+// TestGitCloner_CloneWorktrees_SharedObjectStore は CloneWorktrees が依存する
+// git の手順（1回の fetch で複数 SHA 取得 → checkout --detach → worktree add --detach）が
+// オブジェクトストアを共有した状態で正しく各 SHA のツリーを展開することを検証する。
+// GitCloner は github URL を組み立てるため（既存 Clone テストと同様）、ここでは
+// file:// リモートに対して runGit で同じコマンド列を実行して確認する。
+// ローカル bare リポジトリは既定で部分クローン(--filter)を許可しないため、
+// 既存のローカル fetch テストに倣い --filter=blob:none は付けない（worktree の
+// 機構検証には影響しない）。
+func TestGitCloner_CloneWorktrees_SharedObjectStore(t *testing.T) {
+	bareURL, sha1, sha2 := setupLocalBareRepoTwoCommits(t)
+
+	cloner := &GitCloner{}
+	parent := t.TempDir()
+	repoDir := filepath.Join(parent, "repo")
+	if err := os.Mkdir(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run := func(args ...string) {
+		t.Helper()
+		if err := cloner.runGit(context.Background(), "git", repoDir, args...); err != nil {
+			t.Fatalf("runGit %v: %v", args, err)
+		}
+	}
+
+	run("init")
+	run("remote", "add", "origin", bareURL)
+	// 2 SHA を1回の fetch でまとめて取得（CloneWorktrees と同じ集約）
+	run("fetch", "--depth=1", "--no-tags", "origin", sha1, sha2)
+	// 先頭 SHA は repoDir を作業ツリーとして使う
+	run("checkout", "--detach", sha1)
+	// 残りは worktree で追加（同一オブジェクトストアを共有）
+	wt1 := filepath.Join(parent, "wt-1")
+	run("worktree", "add", "--detach", wt1, sha2)
+
+	// sha1 の worktree(repoDir) は main.go のみ、foo.go はない
+	if _, err := os.Stat(filepath.Join(repoDir, "main.go")); err != nil {
+		t.Errorf("repoDir(sha1) main.go not found: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repoDir, "foo.go")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("repoDir(sha1) should NOT contain foo.go, got: %v", err)
+	}
+	// sha2 の worktree は foo.go を含む
+	if _, err := os.Stat(filepath.Join(wt1, "foo.go")); err != nil {
+		t.Errorf("wt-1(sha2) foo.go not found: %v", err)
+	}
+
+	// worktree はオブジェクトストアを共有する（.git はファイルで repoDir を指す）
+	gitInfo, err := os.Stat(filepath.Join(wt1, ".git"))
+	if err != nil {
+		t.Fatalf("wt-1 .git not found: %v", err)
+	}
+	if gitInfo.IsDir() {
+		t.Errorf("wt-1 .git should be a file (linked worktree), got directory")
+	}
+
+	// 親ディレクトリ丸ごとの RemoveAll で cleanup が完結する
+	if err := os.RemoveAll(parent); err != nil {
+		t.Fatalf("cleanup RemoveAll: %v", err)
+	}
+	if _, err := os.Stat(parent); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected parent removed, got: %v", err)
+	}
+}
+
+func TestDedupStrings(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"empty", nil, []string{}},
+		{"no dup", []string{"a", "b"}, []string{"a", "b"}},
+		{"dup preserves order", []string{"a", "b", "a", "c", "b"}, []string{"a", "b", "c"}},
+		{"same sha twice", []string{"x", "x"}, []string{"x"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dedupStrings(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len got %v want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("[%d] got %q want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestGitCloner_Clone_BadSHA(t *testing.T) {
 	bareURL, _ := setupLocalBareRepo(t)
 

--- a/backend/internal/infra/analyzer/source_tree.go
+++ b/backend/internal/infra/analyzer/source_tree.go
@@ -70,12 +70,48 @@ func (s *SourceTree) PrepareAtSHA(ctx context.Context, pr domain.PRInfo, token, 
 		return nil, fmt.Errorf("analyzer: clone %s/%s@%s: %w", pr.Owner, pr.Repo, sha, err)
 	}
 
-	// go.mod を持つサブディレクトリを特定し、そこを基点にパッケージをロードする。
-	// clonedRoot はリポジトリルート（GitHub API の相対パス基点）、loadDir は go.mod の親。
-	clonedRoot := cloned.RootDir
-	loadDir, err := findGoModRoot(clonedRoot)
+	ps, err := s.prepareFromDir(ctx, cloned.RootDir, changed)
 	if err != nil {
 		_ = cloned.Cleanup()
+		return nil, err
+	}
+	ps.Cleanup = cloned.Cleanup
+	return ps, nil
+}
+
+// CloneBoth は head/base の2SHAを1リポジトリ共有でcloneし、SHAごとのworktreeを返す。
+// fetchとオブジェクトストアを共有するため、base/headを別々にcloneするより高速・省ディスク
+// （変更のないblobは1度しかfetchしない）。返り値の Cleanup を呼び出し側がdeferで呼ぶ。
+func (s *SourceTree) CloneBoth(ctx context.Context, pr domain.PRInfo, token string) (*ClonedWorktrees, error) {
+	cw, err := s.Cloner.CloneWorktrees(ctx, WorktreesRequest{
+		Owner: pr.Owner,
+		Repo:  pr.Repo,
+		Token: token,
+		SHAs:  []string{pr.HeadSHA, pr.BaseSHA},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("analyzer: clone %s/%s (head=%s base=%s): %w", pr.Owner, pr.Repo, pr.HeadSHA, pr.BaseSHA, err)
+	}
+	return cw, nil
+}
+
+// PrepareFromDir はclone済みの作業ツリー（rootDir）に対して fast load →
+// 変更パッケージ特定 → 近傍フルロードを行う。cloneを行わない点だけが PrepareAtSHA と
+// 異なり、CloneBoth と組み合わせてcloneを共有する用途に使う。
+// 返す PreparedSource の Cleanup は nil（共有tmp dirの後始末は CloneBoth 側の Cleanup が担う）。
+func (s *SourceTree) PrepareFromDir(ctx context.Context, rootDir string, changed []domain.ChangedFile) (*PreparedSource, error) {
+	return s.prepareFromDir(ctx, rootDir, changed)
+}
+
+// prepareFromDir はclone済みディレクトリを起点に2フェーズロードを実行する共通処理。
+// clone/cleanupには関与しない（エラー時もcleanupを呼ばず、呼び出し側の責務とする）。
+// 返す PreparedSource の Cleanup は常に nil。
+func (s *SourceTree) prepareFromDir(ctx context.Context, rootDir string, changed []domain.ChangedFile) (*PreparedSource, error) {
+	// go.mod を持つサブディレクトリを特定し、そこを基点にパッケージをロードする。
+	// clonedRoot はリポジトリルート（GitHub API の相対パス基点）、loadDir は go.mod の親。
+	clonedRoot := rootDir
+	loadDir, err := findGoModRoot(clonedRoot)
+	if err != nil {
 		return nil, fmt.Errorf("analyzer: find go.mod in %s: %w", clonedRoot, err)
 	}
 
@@ -84,7 +120,6 @@ func (s *SourceTree) PrepareAtSHA(ctx context.Context, pr domain.PRInfo, token, 
 	t0 := time.Now()
 	fastPkgs, err := s.Loader.FastLoad(ctx, loadDir)
 	if err != nil {
-		_ = cloned.Cleanup()
 		return nil, fmt.Errorf("analyzer: fast-load packages at %s: %w", loadDir, err)
 	}
 	log.Printf("analyzer: phase1 FastLoad(%d pkgs) took %s", len(fastPkgs), time.Since(t0))
@@ -93,7 +128,6 @@ func (s *SourceTree) PrepareAtSHA(ctx context.Context, pr domain.PRInfo, token, 
 	// 進む前に reject する。型ロードやジョブタイムアウトが無言で発火するのを防ぎ、
 	// ユーザーに「大規模リポジトリは未対応」と明示するための入口側ガード。
 	if len(fastPkgs) > maxFastLoadPackages {
-		_ = cloned.Cleanup()
 		return nil, fmt.Errorf("%w: detected %d packages (limit %d)", ErrRepositoryTooLarge, len(fastPkgs), maxFastLoadPackages)
 	}
 
@@ -119,7 +153,6 @@ func (s *SourceTree) PrepareAtSHA(ctx context.Context, pr domain.PRInfo, token, 
 			RootDir:             loadDir,
 			ChangedPackages:     nil,
 			ChangedFileAbsPaths: changedFileAbsPaths,
-			Cleanup:             cloned.Cleanup,
 		}, nil
 	}
 
@@ -137,7 +170,6 @@ func (s *SourceTree) PrepareAtSHA(ctx context.Context, pr domain.PRInfo, token, 
 	t1 := time.Now()
 	result, err := s.Loader.Load(ctx, loadDir, neighborhood)
 	if err != nil {
-		_ = cloned.Cleanup()
 		return nil, fmt.Errorf("analyzer: load packages at %s: %w", loadDir, err)
 	}
 	log.Printf("analyzer: phase2 Load(%d pkgs) took %s", len(result.Packages), time.Since(t1))
@@ -149,7 +181,6 @@ func (s *SourceTree) PrepareAtSHA(ctx context.Context, pr domain.PRInfo, token, 
 		LoadErrors:          result.Errors,
 		ChangedPackages:     changedPkgs,
 		ChangedFileAbsPaths: changedFileAbsPaths,
-		Cleanup:             cloned.Cleanup,
 	}, nil
 }
 

--- a/backend/internal/infra/analyzer/source_tree_test.go
+++ b/backend/internal/infra/analyzer/source_tree_test.go
@@ -29,10 +29,28 @@ func (f *fakeCloner) Clone(_ context.Context, _ CloneRequest) (*ClonedRepo, erro
 	}, nil
 }
 
+func (f *fakeCloner) CloneWorktrees(_ context.Context, req WorktreesRequest) (*ClonedWorktrees, error) {
+	dirs := make(map[string]string, len(req.SHAs))
+	for _, sha := range req.SHAs {
+		dirs[sha] = f.fixtureDir
+	}
+	return &ClonedWorktrees{
+		Dirs: dirs,
+		Cleanup: func() error {
+			f.cleanupCalled = true
+			return nil
+		},
+	}, nil
+}
+
 // errorCloner は常にエラーを返すCloner。
 type errorCloner struct{}
 
 func (e *errorCloner) Clone(_ context.Context, _ CloneRequest) (*ClonedRepo, error) {
+	return nil, ErrCloneFailed
+}
+
+func (e *errorCloner) CloneWorktrees(_ context.Context, _ WorktreesRequest) (*ClonedWorktrees, error) {
 	return nil, ErrCloneFailed
 }
 
@@ -118,6 +136,74 @@ func G() int { return 42 }
 
 	// Cleanup でdirが（fakeなので実際には消えないが）呼ばれることを確認
 	if err := ps.Cleanup(); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if !fc.cleanupCalled {
+		t.Error("expected fakeCloner.Cleanup to be called")
+	}
+}
+
+func TestSourceTree_CloneBoth_PrepareFromDir(t *testing.T) {
+	// fixture: 2パッケージ構成のGoモジュール
+	dir := writeFixture(t, map[string]string{
+		"go.mod": "module example.com/fixture\n\ngo 1.21\n",
+		"pkg/a/a.go": `package a
+
+import "example.com/fixture/pkg/b"
+
+func F() int { return b.G() }
+`,
+		"pkg/b/b.go": `package b
+
+func G() int { return 42 }
+`,
+	})
+
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fc := &fakeCloner{fixtureDir: resolvedDir}
+	st := NewSourceTree(fc, NewGoPackageLoader())
+
+	pr := domain.PRInfo{Owner: "owner", Repo: "repo", HeadSHA: "head-sha", BaseSHA: "base-sha"}
+	changed := []domain.ChangedFile{
+		{Filename: "pkg/a/a.go", Status: "modified"},
+	}
+
+	cw, err := st.CloneBoth(context.Background(), pr, "")
+	if err != nil {
+		t.Fatalf("CloneBoth: %v", err)
+	}
+	// head/base 両方の worktree が返ること（fake は同じ fixture を指す）
+	headDir, ok := cw.Dirs[pr.HeadSHA]
+	if !ok {
+		t.Fatalf("missing worktree for head %s", pr.HeadSHA)
+	}
+	if _, ok := cw.Dirs[pr.BaseSHA]; !ok {
+		t.Fatalf("missing worktree for base %s", pr.BaseSHA)
+	}
+
+	ps, err := st.PrepareFromDir(context.Background(), headDir, changed)
+	if err != nil {
+		t.Fatalf("PrepareFromDir: %v", err)
+	}
+	if ps.RepoRoot != resolvedDir {
+		t.Errorf("RepoRoot: got %q, want %q", ps.RepoRoot, resolvedDir)
+	}
+	if len(ps.Packages) == 0 {
+		t.Error("Packages should not be empty")
+	}
+	if len(ps.ChangedPackages) != 1 {
+		t.Errorf("ChangedPackages: got %v, want 1 entry", ps.ChangedPackages)
+	}
+	// PrepareFromDir は clone を持たないため Cleanup は nil（後始末は CloneBoth 側）
+	if ps.Cleanup != nil {
+		t.Error("PrepareFromDir should return PreparedSource with nil Cleanup")
+	}
+
+	if err := cw.Cleanup(); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 	if !fc.cleanupCalled {

--- a/backend/internal/infra/job/worker.go
+++ b/backend/internal/infra/job/worker.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"sync"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -26,9 +25,11 @@ type jobStore interface {
 }
 
 // sourceTreePreparer はワーカーが使うソースツリー準備インターフェース。
+// CloneBoth で head/base を1リポジトリ共有でcloneし、各worktreeを PrepareFromDir で
+// ロードする（cloneとload/buildを分離し、cloneのみ共有・load/buildは並列を維持する）。
 type sourceTreePreparer interface {
-	Prepare(ctx context.Context, pr domain.PRInfo, token string, changed []domain.ChangedFile) (*analyzer.PreparedSource, error)
-	PrepareAtSHA(ctx context.Context, pr domain.PRInfo, token, sha string, changed []domain.ChangedFile) (*analyzer.PreparedSource, error)
+	CloneBoth(ctx context.Context, pr domain.PRInfo, token string) (*analyzer.ClonedWorktrees, error)
+	PrepareFromDir(ctx context.Context, rootDir string, changed []domain.ChangedFile) (*analyzer.PreparedSource, error)
 }
 
 // defaultJobTimeout は1ジョブの解析にかける時間の上限のデフォルト値。
@@ -167,18 +168,14 @@ func (w *Worker) process(ctx context.Context, item Item) {
 	}
 	log.Printf("worker: ListChangedGoFiles took %s (%d files)", time.Since(t0), len(changed))
 
-	// クローン完了後、最初にグラフ構築へ入った時点で一度だけ build_graph フェーズへ移す
-	// (base/head が並列なため sync.Once で先着のみ反映する)。
-	var buildOnce sync.Once
-	onBuild := func() { buildOnce.Do(func() { setPhase(domain.JobPhaseBuildGraph) }) }
+	// clone（共有）完了後、グラフ構築フェーズへ移す。
+	onCloneDone := func() { setPhase(domain.JobPhaseBuildGraph) }
 
 	t1 := time.Now()
-	headGraph, baseGraph, cleanups, err := w.buildBothGraphs(ctx, j.PR, item.Token, changed, onBuild)
+	headGraph, baseGraph, cleanup, err := w.buildBothGraphs(ctx, j.PR, item.Token, changed, onCloneDone)
 	defer func() {
-		for _, c := range cleanups {
-			if c != nil {
-				_ = c()
-			}
+		if cleanup != nil {
+			_ = cleanup()
 		}
 	}()
 	if err != nil {
@@ -243,28 +240,43 @@ func (w *Worker) process(ctx context.Context, item Item) {
 	}
 }
 
-// buildBothGraphs は head/base 両方の callgraph を errgroup で並列に構築する。
-// 戻り値の cleanups スライスには各 PreparedSource.Cleanup が入る（呼び出し元が defer で全部呼ぶこと）。
+// buildBothGraphs は head/base 両方の callgraph を構築する。
+// clone は CloneBoth で1リポジトリ共有（1回の fetch）にまとめ、その後の
+// load（PrepareFromDir）と Build は errgroup で base/head 並列に実行する。
+// 戻り値の cleanup は共有tmp dirを削除する単一のクロージャ（呼び出し元が defer で呼ぶこと）。
 // 一方が失敗した時点で他方の ctx もキャンセルされ、エラーが返る。
-// onBuild は各 Prepare（クローン）完了後・Build 開始前に呼ばれる進捗通知コールバック。
+// onCloneDone は clone 完了後・Build 開始前に一度だけ呼ばれる進捗通知コールバック。
 func (w *Worker) buildBothGraphs(
 	ctx context.Context,
 	pr domain.PRInfo,
 	token string,
 	changed []domain.ChangedFile,
-	onBuild func(),
-) (head, base *domain.Graph, cleanups []func() error, err error) {
-	cleanups = make([]func() error, 2)
+	onCloneDone func(),
+) (head, base *domain.Graph, cleanup func() error, err error) {
+	// base/head を1リポジトリ共有で clone（fetch/オブジェクトストアを共有）。
+	cw, err := w.sourceTree.CloneBoth(ctx, pr, token)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("clone base/head: %w", err)
+	}
+	cleanup = cw.Cleanup
+	onCloneDone()
+
+	headDir, ok := cw.Dirs[pr.HeadSHA]
+	if !ok {
+		return nil, nil, cleanup, fmt.Errorf("clone base/head: missing worktree for head %s", pr.HeadSHA)
+	}
+	baseDir, ok := cw.Dirs[pr.BaseSHA]
+	if !ok {
+		return nil, nil, cleanup, fmt.Errorf("clone base/head: missing worktree for base %s", pr.BaseSHA)
+	}
 
 	eg, egCtx := errgroup.WithContext(ctx)
 
 	eg.Go(func() error {
-		prepared, err := w.sourceTree.Prepare(egCtx, pr, token, changed)
+		prepared, err := w.sourceTree.PrepareFromDir(egCtx, headDir, changed)
 		if err != nil {
 			return fmt.Errorf("head prepare: %w", err)
 		}
-		cleanups[0] = prepared.Cleanup
-		onBuild()
 		g, err := w.cgBuilder.Build(egCtx, prepared.Packages, prepared.ChangedPackages, prepared.ChangedFileAbsPaths, prepared.RepoRoot)
 		if err != nil {
 			return fmt.Errorf("head build: %w", err)
@@ -275,12 +287,10 @@ func (w *Worker) buildBothGraphs(
 
 	eg.Go(func() error {
 		baseChanged := domain.NormalizeChangedForBase(changed)
-		prepared, err := w.sourceTree.PrepareAtSHA(egCtx, pr, token, pr.BaseSHA, baseChanged)
+		prepared, err := w.sourceTree.PrepareFromDir(egCtx, baseDir, baseChanged)
 		if err != nil {
 			return fmt.Errorf("base prepare: %w", err)
 		}
-		cleanups[1] = prepared.Cleanup
-		onBuild()
 		g, err := w.cgBuilder.Build(egCtx, prepared.Packages, prepared.ChangedPackages, prepared.ChangedFileAbsPaths, prepared.RepoRoot)
 		if err != nil {
 			return fmt.Errorf("base build: %w", err)
@@ -290,9 +300,9 @@ func (w *Worker) buildBothGraphs(
 	})
 
 	if err = eg.Wait(); err != nil {
-		return nil, nil, cleanups, err
+		return nil, nil, cleanup, err
 	}
-	return head, base, cleanups, nil
+	return head, base, cleanup, nil
 }
 
 func workerRandomID() string {

--- a/backend/internal/infra/job/worker_test.go
+++ b/backend/internal/infra/job/worker_test.go
@@ -111,22 +111,33 @@ type fakeSourceTree struct {
 	prepared *analyzer.PreparedSource
 	err      error
 
-	// 観測用: 何回呼ばれたか / どの SHA で呼ばれたか
-	prepareCalls      int
-	prepareAtSHACalls int
-	prepareAtSHAs     []string
-	baseChanged       []domain.ChangedFile
+	// 観測用: 何回呼ばれたか / どの worktree で呼ばれたか
+	cloneBothCalls      int
+	prepareFromDirCalls int
+	headDir, baseDir    string
+	changedByDir        map[string][]domain.ChangedFile
 }
 
-func (s *fakeSourceTree) Prepare(_ context.Context, _ domain.PRInfo, _ string, _ []domain.ChangedFile) (*analyzer.PreparedSource, error) {
-	s.prepareCalls++
-	return s.prepared, s.err
+func (s *fakeSourceTree) CloneBoth(_ context.Context, pr domain.PRInfo, _ string) (*analyzer.ClonedWorktrees, error) {
+	s.cloneBothCalls++
+	if s.err != nil {
+		return nil, s.err
+	}
+	// SHA ごとに別ディレクトリを返し、head/base の PrepareFromDir を区別できるようにする。
+	s.headDir = "dir-" + pr.HeadSHA
+	s.baseDir = "dir-" + pr.BaseSHA
+	return &analyzer.ClonedWorktrees{
+		Dirs:    map[string]string{pr.HeadSHA: s.headDir, pr.BaseSHA: s.baseDir},
+		Cleanup: func() error { return nil },
+	}, nil
 }
 
-func (s *fakeSourceTree) PrepareAtSHA(_ context.Context, _ domain.PRInfo, _, sha string, changed []domain.ChangedFile) (*analyzer.PreparedSource, error) {
-	s.prepareAtSHACalls++
-	s.prepareAtSHAs = append(s.prepareAtSHAs, sha)
-	s.baseChanged = changed
+func (s *fakeSourceTree) PrepareFromDir(_ context.Context, rootDir string, changed []domain.ChangedFile) (*analyzer.PreparedSource, error) {
+	s.prepareFromDirCalls++
+	if s.changedByDir == nil {
+		s.changedByDir = make(map[string][]domain.ChangedFile)
+	}
+	s.changedByDir[rootDir] = changed
 	return s.prepared, s.err
 }
 
@@ -236,15 +247,18 @@ func TestWorker_HappyPath(t *testing.T) {
 			t.Errorf("phase[%d]: got %s want %s", i, jobs.phaseCalls[i], p)
 		}
 	}
-	// base/head が両方呼ばれたことを確認
-	if st.prepareCalls != 1 {
-		t.Errorf("Prepare (head) calls: got %d want 1", st.prepareCalls)
+	// clone は1回に共有され、head/base それぞれ PrepareFromDir が呼ばれたことを確認
+	if st.cloneBothCalls != 1 {
+		t.Errorf("CloneBoth calls: got %d want 1", st.cloneBothCalls)
 	}
-	if st.prepareAtSHACalls != 1 {
-		t.Errorf("PrepareAtSHA (base) calls: got %d want 1", st.prepareAtSHACalls)
+	if st.prepareFromDirCalls != 2 {
+		t.Errorf("PrepareFromDir calls: got %d want 2", st.prepareFromDirCalls)
 	}
-	if len(st.prepareAtSHAs) != 1 || st.prepareAtSHAs[0] != "base-sha" {
-		t.Errorf("PrepareAtSHA SHA: got %v want [base-sha]", st.prepareAtSHAs)
+	if _, ok := st.changedByDir[st.headDir]; !ok {
+		t.Errorf("PrepareFromDir not called for head worktree %q", st.headDir)
+	}
+	if _, ok := st.changedByDir[st.baseDir]; !ok {
+		t.Errorf("PrepareFromDir not called for base worktree %q", st.baseDir)
 	}
 }
 
@@ -278,12 +292,13 @@ func TestWorker_BaseSHA_RenameNormalized(t *testing.T) {
 
 	w.process(context.Background(), Item{JobID: "job-r", Token: "tok"})
 
-	if len(st.baseChanged) != 2 {
-		t.Fatalf("base changed len=%d want 2 (added 除外)", len(st.baseChanged))
+	baseChanged := st.changedByDir[st.baseDir]
+	if len(baseChanged) != 2 {
+		t.Fatalf("base changed len=%d want 2 (added 除外)", len(baseChanged))
 	}
 	// renamed が PreviousFilename に置換されているか
 	var found bool
-	for _, f := range st.baseChanged {
+	for _, f := range baseChanged {
 		if f.Status == domain.FileStatusRenamed && f.Filename == "pkg/a/old.go" {
 			found = true
 		}
@@ -347,15 +362,15 @@ func TestWorker_ContextCancel_StopsLoop(t *testing.T) {
 	}
 }
 
-// blockingSourceTree は ctx がキャンセル/タイムアウトされるまで Prepare をブロックする。
+// blockingSourceTree は ctx がキャンセル/タイムアウトされるまで CloneBoth をブロックする。
 type blockingSourceTree struct{}
 
-func (s *blockingSourceTree) Prepare(ctx context.Context, _ domain.PRInfo, _ string, _ []domain.ChangedFile) (*analyzer.PreparedSource, error) {
+func (s *blockingSourceTree) CloneBoth(ctx context.Context, _ domain.PRInfo, _ string) (*analyzer.ClonedWorktrees, error) {
 	<-ctx.Done()
 	return nil, ctx.Err()
 }
 
-func (s *blockingSourceTree) PrepareAtSHA(ctx context.Context, _ domain.PRInfo, _, _ string, _ []domain.ChangedFile) (*analyzer.PreparedSource, error) {
+func (s *blockingSourceTree) PrepareFromDir(ctx context.Context, _ string, _ []domain.ChangedFile) (*analyzer.PreparedSource, error) {
 	<-ctx.Done()
 	return nil, ctx.Err()
 }


### PR DESCRIPTION
親: #82（解析パフォーマンス B群: 1ジョブのレイテンシ削減）／ロードマップ #79 の PR-G

## 背景
base/head の callgraph を作るため、これまで両 SHA を**独立に 2 回 clone** していた。
2 回の `git fetch`、別々のオブジェクトストア、base/head で共通の blob の二重取得が発生していた（PR-F 後の残る効き幅として #82 に記載）。

## 施策
1 リポジトリに両 SHA を **1 回の fetch** でまとめて取得し、SHA ごとに `git worktree` を生やす方式へ変更。共通 blob は 1 度しか取得されず、fetch 回数・ディスクを削減する。

- `analyzer.Cloner` に `CloneWorktrees` を追加（`GitCloner` が実装）
  - `git init` → `remote add` → `fetch --depth=1 --no-tags --filter=blob:none origin <head> <base>` を 1 回
  - 先頭 SHA は共有 repo を作業ツリーに使い、残りは `git worktree add --detach`
  - cleanup は共有 tmp dir の `RemoveAll` で完結（worktree ごとの後始末不要）
- `SourceTree`: clone と load を分離
  - `CloneBoth`（共有 clone）+ `PrepareFromDir`（clone 済みディレクトリから 2 フェーズロード）を追加
  - `PrepareAtSHA` は `Clone`→`prepareFromDir` へ内部リファクタ（**挙動不変**）。単一 SHA 用の `Prepare`/`PrepareAtSHA` は bench の head-only 用に維持
- `worker.buildBothGraphs` / bench `runBoth`: clone を 1 回に集約したうえで、load(`PrepareFromDir`)+`Build` を errgroup で base/head 並列実行（**既存の並列パイプラインは維持**）

出力グラフは原理上不変（clone 経路が変わるだけで、ロード対象・解析ロジックは同一）。

## テスト
- `TestGitCloner_CloneWorktrees_SharedObjectStore`: 実 git（file:// remote・2 コミット）で「1 fetch → checkout --detach → worktree add --detach」が各 SHA のツリーを正しく展開し、worktree が `.git` ファイル（リンク型＝オブジェクトストア共有）になることを検証
- `TestDedupStrings`: SHA 重複除去（順序保持）
- `TestSourceTree_CloneBoth_PrepareFromDir`: CloneBoth→PrepareFromDir の結合、PrepareFromDir の `Cleanup` が nil（共有 cleanup は CloneBoth 側）
- worker テストは新インターフェース（`CloneBoth`/`PrepareFromDir`）に更新。HappyPath は clone 1 回・PrepareFromDir 2 回、base の changed 正規化を検証
- `gofmt` / `go vet` / `go test ./...` グリーン

## レビュアー確認項目（計測ゲート・CLI では PAT 必要のため未実施）
- [ ] `bench -both` で代表 PR（小/中/上限近く）の**ノード/エッジ数が本 PR 前後で完全一致**すること
- [ ] `[3a] CloneBoth` のログ時間 + 全体時間/ピークメモリが、従来の 2 回 clone より改善（少なくとも悪化しない）こと
- [ ] private リポジトリ（token 認証）でも clone/worktree が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)