### PR TITLE
feat: グラフに関数名検索・ジャンプ機能を追加 (#91)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -149,7 +149,8 @@ ID やファイルパスは必ず mono にする。視認性と「これはコ�
 | `ClusterGroup` | 展開中クラスタの背景コンテナ。子ノードを `parentId` で内包 |
 | `SuperClusterNode` | 折りたたみ中クラスタのスーパーノード。クリックで展開 |
 | `FunctionDetailsPanel` | 右パネル。クラスタラベル・レイヤー・GitHub 該当行リンク・diff |
-| `FocusLegend` | フォーカスモード中に左上に出る凡例（呼び出し元/先の方向色と件数） |
+| `GraphSearch` | グラフ左上の検索ボックス。関数名/パッケージをインクリメンタル検索→候補選択で展開+選択+中央寄せ（`fitView`）。折りたたみ中クラスタ内のノードも親を開いて到達する |
+| `FocusLegend` | フォーカスモード中に左上（検索ボックスの下）に出る凡例（呼び出し元/先の方向色と件数） |
 | `DiffViewer` | `@monaco-editor/react` で before/after 表示 |
 | `ClusterSidebar` | クラスタ一覧（実装位置: `layout/`） |
 

--- a/frontend/src/components/graph/DependencyGraph.tsx
+++ b/frontend/src/components/graph/DependencyGraph.tsx
@@ -15,6 +15,7 @@ import FunctionNode from './FunctionNode'
 import ClusterGroup from './ClusterGroup'
 import SuperClusterNode from './SuperClusterNode'
 import GraphControls from './GraphControls'
+import GraphSearch, { type SearchCandidate } from './GraphSearch'
 import FocusLegend from './FocusLegend'
 import { layoutGraph, type LayoutResult } from '@/lib/graphLayout'
 import {
@@ -53,6 +54,11 @@ type Props = {
   onToggleCluster: (key: string) => void
   onExpandAll: () => void
   onCollapseAll: () => void
+  searchCandidates: SearchCandidate[]
+  onJump: (id: string) => void
+  // 検索ジャンプ等でこの target が変わったら、当該ノードが配置され次第そこへ中央寄せする。
+  // nonce は同一ノードへの再ジャンプでも再中央寄せするための世代番号。
+  centerTarget: { nodeId: string; nonce: number } | null
 }
 
 function GraphInner({
@@ -68,6 +74,9 @@ function GraphInner({
   onToggleCluster,
   onExpandAll,
   onCollapseAll,
+  searchCandidates,
+  onJump,
+  centerTarget,
 }: Props) {
   const { fitView } = useReactFlow()
 
@@ -107,6 +116,26 @@ function GraphInner({
     const raf = requestAnimationFrame(() => fitView({ duration: 300 }))
     return () => cancelAnimationFrame(raf)
   }, [layoutSource, data, layoutNodes, fitView])
+
+  // 検索ジャンプの中央寄せ。ジャンプ要求（centerTarget.nonce 変化）を pending に記録し、
+  // 対象ノードが現在のレイアウトに現れ次第そこへ寄せる。折りたたみクラスタ内のノードは
+  // 親展開 → 再レイアウト後に初めて layoutNodes に現れるため、layoutNodes 変化でも再評価する。
+  const pendingCenterRef = useRef<string | null>(null)
+  const processedNonceRef = useRef<number>(-1)
+  useEffect(() => {
+    if (centerTarget && centerTarget.nonce !== processedNonceRef.current) {
+      processedNonceRef.current = centerTarget.nonce
+      pendingCenterRef.current = centerTarget.nodeId
+    }
+    const targetId = pendingCenterRef.current
+    if (!targetId) return
+    if (!layoutNodes.some((n) => n.id === targetId)) return // まだ配置されていない（展開待ち）
+    pendingCenterRef.current = null
+    const raf = requestAnimationFrame(() =>
+      fitView({ nodes: [{ id: targetId }], duration: 500, maxZoom: 1.2, padding: 0.6 }),
+    )
+    return () => cancelAnimationFrame(raf)
+  }, [centerTarget, layoutNodes, fitView])
 
   // フォーカス: 選択ノードが現在のレイアウトに存在するときだけ有効化する
   // （クラスタ折りたたみ等で非表示になった選択は無視し、全体減光を避ける）。
@@ -216,11 +245,10 @@ function GraphInner({
           </div>
         </Panel>
       )}
-      {focus && (
-        <Panel position="top-left">
-          <FocusLegend callerCount={focus.callerCount} calleeCount={focus.calleeCount} />
-        </Panel>
-      )}
+      <Panel position="top-left" className="flex flex-col gap-2">
+        <GraphSearch candidates={searchCandidates} onJump={onJump} />
+        {focus && <FocusLegend callerCount={focus.callerCount} calleeCount={focus.calleeCount} />}
+      </Panel>
       <Controls position="bottom-left" />
       {nodes.length <= MINIMAP_HIDE_NODE_THRESHOLD && (
         <MiniMap

--- a/frontend/src/components/graph/GraphSearch.tsx
+++ b/frontend/src/components/graph/GraphSearch.tsx
@@ -1,0 +1,139 @@
+import { useMemo, useRef, useState, useCallback, useEffect } from 'react'
+import { Input } from '@/components/ui/input'
+
+export type SearchCandidate = {
+  id: string
+  name: string
+  package: string
+}
+
+type Props = {
+  candidates: SearchCandidate[]
+  onJump: (id: string) => void
+}
+
+// 候補ドロップダウンに一度に表示する最大件数。大規模グラフで数千件を
+// DOM に出すとキー入力ごとに重くなるため上限を設ける（超過分は件数のみ通知）。
+const MAX_RESULTS = 40
+
+/**
+ * グラフ上の関数を名前 / パッケージで絞り込み、選択でそのノードへジャンプする検索ボックス。
+ * ジャンプ後の展開・選択・中央寄せは親（onJump）側で行う。
+ */
+export default function GraphSearch({ candidates, onJump }: Props) {
+  const [query, setQuery] = useState('')
+  const [open, setOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(0)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const q = query.trim().toLowerCase()
+
+  const { results, total } = useMemo(() => {
+    if (!q) return { results: [] as SearchCandidate[], total: 0 }
+    const matched: SearchCandidate[] = []
+    let count = 0
+    for (const c of candidates) {
+      if (c.name.toLowerCase().includes(q) || c.package.toLowerCase().includes(q)) {
+        count++
+        if (matched.length < MAX_RESULTS) matched.push(c)
+      }
+    }
+    return { results: matched, total: count }
+  }, [candidates, q])
+
+  // 外側クリックでドロップダウンを閉じる。
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (e: PointerEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    return () => document.removeEventListener('pointerdown', onPointerDown)
+  }, [open])
+
+  const jump = useCallback(
+    (c: SearchCandidate) => {
+      onJump(c.id)
+      setQuery('')
+      setOpen(false)
+    },
+    [onJump],
+  )
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setQuery('')
+        setOpen(false)
+        return
+      }
+      if (results.length === 0) return
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setActiveIndex((i) => (i + 1) % results.length)
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setActiveIndex((i) => (i - 1 + results.length) % results.length)
+      } else if (e.key === 'Enter') {
+        e.preventDefault()
+        const c = results[activeIndex]
+        if (c) jump(c)
+      }
+    },
+    [results, activeIndex, jump],
+  )
+
+  const showDropdown = open && q.length > 0
+
+  return (
+    <div ref={containerRef} className="w-64">
+      <Input
+        type="text"
+        value={query}
+        onChange={(e) => {
+          setQuery(e.target.value)
+          setActiveIndex(0)
+          setOpen(true)
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={handleKeyDown}
+        placeholder="関数・パッケージを検索"
+        aria-label="関数・パッケージを検索"
+        className="h-8 bg-white text-xs shadow-md"
+      />
+      {showDropdown && (
+        <div className="mt-1 max-h-72 overflow-y-auto rounded-lg border border-stone-200 bg-white shadow-md">
+          {results.length === 0 ? (
+            <p className="px-2.5 py-2 text-xs text-stone-400">一致する関数がありません</p>
+          ) : (
+            <ul>
+              {results.map((c, i) => (
+                <li key={c.id}>
+                  <button
+                    type="button"
+                    // pointerdown による外側クリック判定より前に選択を確定させたいので
+                    // クリックで確定する（onMouseDown だと input の blur と競合しにくい）。
+                    onClick={() => jump(c)}
+                    onMouseEnter={() => setActiveIndex(i)}
+                    className={[
+                      'flex w-full flex-col items-start gap-0.5 px-2.5 py-1.5 text-left transition-colors',
+                      i === activeIndex ? 'bg-stone-100' : 'hover:bg-stone-50',
+                    ].join(' ')}
+                  >
+                    <span className="font-mono text-xs text-stone-800">{c.name}</span>
+                    <span className="font-mono text-[10px] text-stone-400">{c.package}</span>
+                  </button>
+                </li>
+              ))}
+              {total > results.length && (
+                <li className="px-2.5 py-1.5 text-[10px] text-stone-400">
+                  他 {total - results.length} 件（絞り込んでください）
+                </li>
+              )}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/graph/GraphSearch.tsx
+++ b/frontend/src/components/graph/GraphSearch.tsx
@@ -41,6 +41,14 @@ export default function GraphSearch({ candidates, onJump }: Props) {
     return { results: matched, total: count }
   }, [candidates, q])
 
+  const safeIndex = results.length === 0 ? 0 : activeIndex % results.length
+
+  useEffect(() => {
+    if (!open) return
+    const el = containerRef.current?.querySelector('[data-active="true"]')
+    el?.scrollIntoView({ block: 'nearest' })
+  }, [safeIndex, open])
+
   // 外側クリックでドロップダウンを閉じる。
   useEffect(() => {
     if (!open) return
@@ -76,11 +84,11 @@ export default function GraphSearch({ candidates, onJump }: Props) {
         setActiveIndex((i) => (i - 1 + results.length) % results.length)
       } else if (e.key === 'Enter') {
         e.preventDefault()
-        const c = results[activeIndex]
+        const c = results[safeIndex]
         if (c) jump(c)
       }
     },
-    [results, activeIndex, jump],
+    [results, safeIndex, jump],
   )
 
   const showDropdown = open && q.length > 0
@@ -111,13 +119,14 @@ export default function GraphSearch({ candidates, onJump }: Props) {
                 <li key={c.id}>
                   <button
                     type="button"
+                    data-active={i === safeIndex}
                     // pointerdown による外側クリック判定より前に選択を確定させたいので
                     // クリックで確定する（onMouseDown だと input の blur と競合しにくい）。
                     onClick={() => jump(c)}
                     onMouseEnter={() => setActiveIndex(i)}
                     className={[
                       'flex w-full flex-col items-start gap-0.5 px-2.5 py-1.5 text-left transition-colors',
-                      i === activeIndex ? 'bg-stone-100' : 'hover:bg-stone-50',
+                      i === safeIndex ? 'bg-stone-100' : 'hover:bg-stone-50',
                     ].join(' ')}
                   >
                     <span className="font-mono text-xs text-stone-800">{c.name}</span>

--- a/frontend/src/pages/AnalysisGraphView.tsx
+++ b/frontend/src/pages/AnalysisGraphView.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState, useCallback } from 'react'
 import { Link } from 'react-router-dom'
 import type { LayerKind, AnyFlowNode } from '@/types/graph'
-import type { Cluster, ClusterMode, DiffFile } from '@/types/api'
+import type { Cluster, ClusterMode, DiffFile, GraphResponse } from '@/types/api'
 import { useGraph } from '@/hooks/useGraph'
 import { useDiff } from '@/hooks/useDiff'
 import { inferLayer } from '@/lib/layerInference'
@@ -18,6 +18,7 @@ import {
 import AppShell from '@/components/layout/AppShell'
 import PRMetaBar from '@/components/layout/PRMetaBar'
 import DependencyGraph from '@/components/graph/DependencyGraph'
+import type { SearchCandidate } from '@/components/graph/GraphSearch'
 import FunctionDetailsPanel from '@/components/graph/FunctionDetailsPanel'
 import CycleAlert from '@/components/graph/CycleAlert'
 import LayeringAlert from '@/components/graph/LayeringAlert'
@@ -40,6 +41,9 @@ export default function AnalysisGraphView({ jobId }: Props) {
   const [expandedClustersOverride, setExpandedClustersOverride] = useState<Set<string> | null>(null)
   // true = 変更影響のみ（diff 1-hop 近傍に絞り込み）、false = 全体グラフ
   const [impactOnly, setImpactOnly] = useState(true)
+  // 検索ジャンプで中央寄せしたいノード。nonce は同一ノードへの再ジャンプでも
+  // グラフ側の effect を再発火させるための世代番号。
+  const [centerTarget, setCenterTarget] = useState<{ nodeId: string; nonce: number } | null>(null)
 
   // 描画に使うグラフ。変更影響ビューでは diff 近傍だけに絞った部分グラフを渡す。
   // クラスタ集計・展開・レイアウトはすべてこの view を基準に行う。
@@ -130,13 +134,13 @@ export default function AnalysisGraphView({ jobId }: Props) {
     setSelectedNodeId(null)
   }, [])
 
-  // CycleAlert からノードを選択された場合: 当該ノードのクラスタを展開し、選択 + フォーカス
-  const handleSelectCycleNode = useCallback(
-    (nodeId: string) => {
-      if (!data) return
-      const target = data.graph.nodes.find((n) => n.id === nodeId)
+  // 指定ノードを可視化する: 折りたたみ中なら親クラスタを展開し、そのノードを選択する。
+  // source は展開判定に使うグラフ（全体 = data / 影響ビュー = view）。
+  const revealNode = useCallback(
+    (source: GraphResponse, nodeId: string) => {
+      const target = source.graph.nodes.find((n) => n.id === nodeId)
       if (!target) return
-      const cluster = data.clusters.find((c) => c.nodes.includes(nodeId))
+      const cluster = source.clusters.find((c) => c.nodes.includes(nodeId))
       if (cluster) {
         const key = makeClusterKey(target.package, cluster.id)
         setExpandedClustersOverride((prev) => {
@@ -149,8 +153,32 @@ export default function AnalysisGraphView({ jobId }: Props) {
       }
       setSelectedNodeId(nodeId)
     },
-    [data, defaultExpandedClusters],
+    [defaultExpandedClusters],
   )
+
+  // CycleAlert / LayeringAlert からノードを選択された場合: 展開 + 選択 + フォーカス
+  const handleSelectCycleNode = useCallback(
+    (nodeId: string) => {
+      if (data) revealNode(data, nodeId)
+    },
+    [data, revealNode],
+  )
+
+  // 検索ボックスから関数を選択: 現在のビュー内で展開 + 選択し、中央へ寄せる。
+  const handleJumpToNode = useCallback(
+    (nodeId: string) => {
+      if (!view) return
+      revealNode(view, nodeId)
+      setCenterTarget((t) => ({ nodeId, nonce: (t?.nonce ?? 0) + 1 }))
+    },
+    [view, revealNode],
+  )
+
+  // 検索候補は現在描画しているビュー（影響のみ / 全体）の全関数ノード。
+  const searchCandidates = useMemo<SearchCandidate[]>(() => {
+    if (!view) return []
+    return view.graph.nodes.map((n) => ({ id: n.id, name: n.name, package: n.package }))
+  }, [view])
 
   // in-degree（被呼び出し数）と新規循環ノード集合はグラフ全体から一度だけ算出する。
   const { inDegree, cycleNodeIds } = useMemo(
@@ -272,6 +300,9 @@ export default function AnalysisGraphView({ jobId }: Props) {
         onToggleCluster={handleToggleCluster}
         onExpandAll={handleExpandAll}
         onCollapseAll={handleCollapseAll}
+        searchCandidates={searchCandidates}
+        onJump={handleJumpToNode}
+        centerTarget={centerTarget}
       />
     </AppShell>
   )


### PR DESCRIPTION
## 概要

グラフに関数名/パッケージの検索・ジャンプ機能を追加。大きめの PR で「目的の1関数にたどり着けない」問題（手でパン&ズームするしかなかった）を解消する。Closes #91。

## 変更点

- **新規 `GraphSearch.tsx`**: 左上の検索ボックス。名前/パッケージをインクリメンタル部分一致で絞り込み（大文字小文字無視）、候補ドロップダウン（関数名 mono + パッケージ caption）を表示。最大 40 件・超過分は件数通知。↑↓ 移動 / Enter 確定 / Esc クリア / 外側クリックで閉じる。`aria-label` 付与、`stone` 基調で DESIGN.md 準拠。
- **`DependencyGraph`**: 検索パネルを左上 Panel に配置（`FocusLegend` はその下に共置）。`centerTarget`(nodeId+nonce) を受け、対象ノードが**レイアウトに現れ次第** `fitView({nodes:[id], maxZoom:1.2})` で中央寄せ。折りたたみクラスタ内ノードは親展開→再レイアウト後に現れるため `layoutNodes` 変化で再評価する。
- **`AnalysisGraphView`**: 展開+選択ロジックを `revealNode(source, id)` に抽出し `handleSelectCycleNode`（CycleAlert/LayeringAlert 経路）と共有。`handleJumpToNode` で「現在ビュー内で展開→選択→中央寄せ」。検索候補は描画中ビュー（変更影響のみ/全体）の全関数ノード。
- **`DESIGN.md`** 3.4 に `GraphSearch` を追記。

関連: #89 / #90（① ELK 階層レイアウト化）に続くグラフUX改善②。

## Test plan

自動:
- [x] `npm run lint`（ESLint）
- [x] `npx tsc -b`（型チェック）
- [x] `npx prettier --write .`
- [x] `npm test`（vitest 既存 8 件パス）

要実機確認（`docker compose up -d` → ブラウザ）:
- [x] 検索ボックスに関数名/パッケージを入力すると候補が絞り込まれる
- [x] 候補を選ぶと折りたたみ中クラスタが開き、対象ノードが選択+中央にパン&ズームされる
- [x] 折りたたみ中クラスタ内のノードも検索でたどり着ける
- [x] 「変更影響のみ / 全体」切替の両方で検索が機能する
- [x] 大規模 PR で入力レスポンスが重くない
- [x] 検索ボックスと FocusLegend / レイアウト計算中トグルのレイアウト干渉がない
- [x] DevTools コンソールにエラー/警告が出ない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
