### PR TITLE
perf: changed_files を別カラムに分離しグラフ読み経路から diff 本文を除外 (#93)

### DIFF
--- a/backend/internal/api/analysis_handler_test.go
+++ b/backend/internal/api/analysis_handler_test.go
@@ -31,6 +31,7 @@ type fakeReadUC struct {
 	analysis *domain.Analysis
 	jobErr   error
 	graphErr error
+	diffErr  error
 	lastMode domain.ClusterMode
 }
 
@@ -41,6 +42,10 @@ func (f *fakeReadUC) GetJob(_ context.Context, _ domain.JobID) (*domain.Job, err
 func (f *fakeReadUC) GetGraph(_ context.Context, _ domain.JobID, mode domain.ClusterMode) (*domain.Analysis, error) {
 	f.lastMode = mode
 	return f.analysis, f.graphErr
+}
+
+func (f *fakeReadUC) GetDiff(_ context.Context, _ domain.JobID) (*domain.Analysis, error) {
+	return f.analysis, f.diffErr
 }
 
 // --- helpers ---

--- a/backend/internal/api/diff_handler.go
+++ b/backend/internal/api/diff_handler.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -11,13 +12,19 @@ import (
 	"github.com/s-sh1m0/u-22_procon/backend/internal/usecase"
 )
 
+// diffReadUseCase は DiffHandler が使うユースケースインターフェース。
+// diff 本文のみ取得できればよく、グラフ読み出し（GetGraph）には依存しない。
+type diffReadUseCase interface {
+	GetDiff(ctx context.Context, id domain.JobID) (*domain.Analysis, error)
+}
+
 // DiffHandler は GET /api/diff/:jobId のハンドラ。
 type DiffHandler struct {
-	read readUseCase
+	read diffReadUseCase
 }
 
 // NewDiffHandler は DiffHandler を返す。
-func NewDiffHandler(read readUseCase) *DiffHandler {
+func NewDiffHandler(read diffReadUseCase) *DiffHandler {
 	return &DiffHandler{read: read}
 }
 
@@ -28,7 +35,7 @@ func (h *DiffHandler) Get(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "jobId is required")
 	}
 
-	analysis, err := h.read.GetGraph(c.Request().Context(), domain.JobID(id), domain.ClusterModeLouvain)
+	analysis, err := h.read.GetDiff(c.Request().Context(), domain.JobID(id))
 	if err != nil {
 		if errors.Is(err, usecase.ErrJobNotFound) {
 			return echo.NewHTTPError(http.StatusNotFound, "job not found")

--- a/backend/internal/api/diff_handler_test.go
+++ b/backend/internal/api/diff_handler_test.go
@@ -48,7 +48,7 @@ func TestDiffGet_Success(t *testing.T) {
 }
 
 func TestDiffGet_NotReady(t *testing.T) {
-	h := NewDiffHandler(&fakeReadUC{graphErr: usecase.ErrJobNotReady})
+	h := NewDiffHandler(&fakeReadUC{diffErr: usecase.ErrJobNotReady})
 
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodGet, "/api/diff/pending-job", nil)

--- a/backend/internal/domain/repository.go
+++ b/backend/internal/domain/repository.go
@@ -5,7 +5,10 @@ import "context"
 // AnalysisRepository は解析結果の永続化インターフェース
 type AnalysisRepository interface {
 	Save(ctx context.Context, a *Analysis) error
+	// FindByID はグラフ結果を返す。diff 本文（ChangedFiles）は読み込まない。
 	FindByID(ctx context.Context, id AnalysisID) (*Analysis, error)
+	// FindDiffByID は diff 本文（ChangedFiles）のみを返す。グラフ本体は読み込まない。
+	FindDiffByID(ctx context.Context, id AnalysisID) (*Analysis, error)
 	FindByPR(ctx context.Context, pr PRInfo) (*Analysis, error)
 }
 

--- a/backend/internal/infra/job/worker_test.go
+++ b/backend/internal/infra/job/worker_test.go
@@ -85,6 +85,10 @@ func (r *fakeAnalysisRepo) FindByID(_ context.Context, _ domain.AnalysisID) (*do
 	return nil, nil
 }
 
+func (r *fakeAnalysisRepo) FindDiffByID(_ context.Context, _ domain.AnalysisID) (*domain.Analysis, error) {
+	return nil, nil
+}
+
 func (r *fakeAnalysisRepo) FindByPR(_ context.Context, _ domain.PRInfo) (*domain.Analysis, error) {
 	return nil, nil
 }

--- a/backend/internal/infra/store/analysis_repo.go
+++ b/backend/internal/infra/store/analysis_repo.go
@@ -34,7 +34,7 @@ func NewAnalysisRepo(db *sql.DB) *AnalysisRepo {
 // changed_files カラムに分離して保存する。これにより /api/graph の読み出しで
 // diff 本文を unmarshal せずに済む。
 func (r *AnalysisRepo) Save(ctx context.Context, a *domain.Analysis) error {
-	resultJSON, err := json.Marshal(*a.Result)
+	resultJSON, err := json.Marshal(a.Result)
 	if err != nil {
 		return fmt.Errorf("marshal cluster result: %w", err)
 	}

--- a/backend/internal/infra/store/analysis_repo.go
+++ b/backend/internal/infra/store/analysis_repo.go
@@ -11,8 +11,9 @@ import (
 	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
 )
 
-// analysisResultJSON は analyses.result カラムに保存する JSON 構造。
-// 旧形式（ClusterResult ベタ）との後方互換のため changed_files は omitempty にする。
+// analysisResultJSON は PR-E 世代の result カラム形式（ClusterResult と diff 本文を
+// 単一 JSON にまとめた形）。現在の Save は ClusterResult と changed_files を別々に
+// 保存するため書き込みでは使わず、旧形式行を読むための後方互換にのみ用いる。
 type analysisResultJSON struct {
 	ClusterResult domain.ClusterResult `json:"cluster_result"`
 	ChangedFiles  []domain.DiffFile    `json:"changed_files,omitempty"`
@@ -28,23 +29,32 @@ func NewAnalysisRepo(db *sql.DB) *AnalysisRepo {
 	return &AnalysisRepo{db: db}
 }
 
-// Save は解析結果を analyses テーブルに保存する。result は JSON でシリアライズする。
+// Save は解析結果を analyses テーブルに保存する。
+// グラフ本体（ClusterResult）は result カラムに、diff 本文（ChangedFiles）は
+// changed_files カラムに分離して保存する。これにより /api/graph の読み出しで
+// diff 本文を unmarshal せずに済む。
 func (r *AnalysisRepo) Save(ctx context.Context, a *domain.Analysis) error {
-	payload := analysisResultJSON{
-		ClusterResult: *a.Result,
-		ChangedFiles:  a.ChangedFiles,
-	}
-	resultJSON, err := json.Marshal(payload)
+	resultJSON, err := json.Marshal(*a.Result)
 	if err != nil {
-		return fmt.Errorf("marshal analysis result: %w", err)
+		return fmt.Errorf("marshal cluster result: %w", err)
+	}
+	// ChangedFiles が nil のとき（diff 収集に失敗した等）は NULL を保存し、
+	// キャッシュ判定（ChangedFiles != nil）で「diff 未取得」として扱えるようにする。
+	var changedCol any
+	if a.ChangedFiles != nil {
+		changedJSON, err := json.Marshal(a.ChangedFiles)
+		if err != nil {
+			return fmt.Errorf("marshal changed files: %w", err)
+		}
+		changedCol = string(changedJSON)
 	}
 	_, err = r.db.ExecContext(ctx,
 		`INSERT INTO analyses
-		 (id, owner, repo, pr_number, pr_title, pr_base_ref, pr_head_ref, pr_base_sha, pr_head_sha, result, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		 (id, owner, repo, pr_number, pr_title, pr_base_ref, pr_head_ref, pr_base_sha, pr_head_sha, result, changed_files, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		string(a.ID), a.PR.Owner, a.PR.Repo, a.PR.Number,
 		a.PR.Title, a.PR.BaseRef, a.PR.HeadRef, a.PR.BaseSHA, a.PR.HeadSHA,
-		string(resultJSON), a.CreatedAt.UTC(),
+		string(resultJSON), changedCol, a.CreatedAt.UTC(),
 	)
 	if err != nil {
 		return fmt.Errorf("insert analysis: %w", err)
@@ -52,7 +62,8 @@ func (r *AnalysisRepo) Save(ctx context.Context, a *domain.Analysis) error {
 	return nil
 }
 
-// FindByID は ID で解析結果を返す。存在しない場合は (nil, nil) を返す。
+// FindByID は ID でグラフ結果を返す。diff 本文（ChangedFiles）は読み込まない
+// （/api/graph の軽量読み出し経路）。存在しない場合は (nil, nil) を返す。
 func (r *AnalysisRepo) FindByID(ctx context.Context, id domain.AnalysisID) (*domain.Analysis, error) {
 	var (
 		owner      string
@@ -78,9 +89,9 @@ func (r *AnalysisRepo) FindByID(ctx context.Context, id domain.AnalysisID) (*dom
 		return nil, fmt.Errorf("query analysis: %w", err)
 	}
 
-	result, changedFiles, err := unmarshalAnalysisResult(resultJSON)
+	result, err := unmarshalClusterResult(resultJSON)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshal analysis result: %w", err)
+		return nil, fmt.Errorf("unmarshal cluster result: %w", err)
 	}
 	return &domain.Analysis{
 		ID: id,
@@ -94,13 +105,38 @@ func (r *AnalysisRepo) FindByID(ctx context.Context, id domain.AnalysisID) (*dom
 			BaseSHA: prBaseSHA,
 			HeadSHA: prHeadSHA,
 		},
-		Result:       result,
-		ChangedFiles: changedFiles,
-		CreatedAt:    createdAt,
+		Result:    result,
+		CreatedAt: createdAt,
 	}, nil
 }
 
-// FindByPR は同一 PR の最新解析結果を返す。存在しない場合は (nil, nil) を返す。
+// FindDiffByID は ID で diff 本文（ChangedFiles）のみを返す（/api/diff の読み出し経路）。
+// グラフ本体（Result）は読み込まない。存在しない場合は (nil, nil) を返す。
+func (r *AnalysisRepo) FindDiffByID(ctx context.Context, id domain.AnalysisID) (*domain.Analysis, error) {
+	var (
+		resultJSON string
+		changedCol sql.NullString
+	)
+	err := r.db.QueryRowContext(ctx,
+		`SELECT result, changed_files FROM analyses WHERE id = ?`,
+		string(id),
+	).Scan(&resultJSON, &changedCol)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query analysis diff: %w", err)
+	}
+
+	changedFiles, err := unmarshalChangedFiles(resultJSON, changedCol)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal changed files: %w", err)
+	}
+	return &domain.Analysis{ID: id, ChangedFiles: changedFiles}, nil
+}
+
+// FindByPR は同一 PR の最新解析結果を返す。キャッシュ判定に使うため
+// diff 本文（ChangedFiles）も復元する。存在しない場合は (nil, nil) を返す。
 func (r *AnalysisRepo) FindByPR(ctx context.Context, pr domain.PRInfo) (*domain.Analysis, error) {
 	var (
 		id         string
@@ -110,13 +146,14 @@ func (r *AnalysisRepo) FindByPR(ctx context.Context, pr domain.PRInfo) (*domain.
 		prBaseSHA  string
 		prHeadSHA  string
 		resultJSON string
+		changedCol sql.NullString
 		createdAt  time.Time
 	)
 	err := r.db.QueryRowContext(ctx,
-		`SELECT id, pr_title, pr_base_ref, pr_head_ref, pr_base_sha, pr_head_sha, result, created_at
+		`SELECT id, pr_title, pr_base_ref, pr_head_ref, pr_base_sha, pr_head_sha, result, changed_files, created_at
 		 FROM analyses WHERE owner=? AND repo=? AND pr_number=? ORDER BY created_at DESC LIMIT 1`,
 		pr.Owner, pr.Repo, pr.Number,
-	).Scan(&id, &prTitle, &prBaseRef, &prHeadRef, &prBaseSHA, &prHeadSHA, &resultJSON, &createdAt)
+	).Scan(&id, &prTitle, &prBaseRef, &prHeadRef, &prBaseSHA, &prHeadSHA, &resultJSON, &changedCol, &createdAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -124,9 +161,13 @@ func (r *AnalysisRepo) FindByPR(ctx context.Context, pr domain.PRInfo) (*domain.
 		return nil, fmt.Errorf("query analysis by PR: %w", err)
 	}
 
-	result, changedFiles, err := unmarshalAnalysisResult(resultJSON)
+	result, err := unmarshalClusterResult(resultJSON)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshal analysis result: %w", err)
+		return nil, fmt.Errorf("unmarshal cluster result: %w", err)
+	}
+	changedFiles, err := unmarshalChangedFiles(resultJSON, changedCol)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal changed files: %w", err)
 	}
 	return &domain.Analysis{
 		ID: domain.AnalysisID(id),
@@ -146,18 +187,40 @@ func (r *AnalysisRepo) FindByPR(ctx context.Context, pr domain.PRInfo) (*domain.
 	}, nil
 }
 
-// unmarshalAnalysisResult は新形式（{cluster_result, changed_files}）と
-// 旧形式（ClusterResult ベタ）の両方を読めるようにする。
-func unmarshalAnalysisResult(raw string) (*domain.ClusterResult, []domain.DiffFile, error) {
-	// 新形式を試みる
-	var payload analysisResultJSON
-	if err := json.Unmarshal([]byte(raw), &payload); err == nil && payload.ClusterResult.Graph.Nodes != nil {
-		return &payload.ClusterResult, payload.ChangedFiles, nil
+// unmarshalClusterResult は result カラムから ClusterResult を取り出す。
+// diff 本文は無視するため、グラフ読み経路で diff を unmarshal しない。
+//   - 現行形式: result は ClusterResult ベタ（diff は changed_files カラム）
+//   - PR-E 形式: result は {cluster_result, changed_files} なので cluster_result を取り出す
+//   - 旧々形式: result は ClusterResult ベタ
+func unmarshalClusterResult(raw string) (*domain.ClusterResult, error) {
+	// PR-E のラッパー形式を試す。
+	var wrapper analysisResultJSON
+	if err := json.Unmarshal([]byte(raw), &wrapper); err == nil && wrapper.ClusterResult.Graph.Nodes != nil {
+		return &wrapper.ClusterResult, nil
 	}
-	// 旧形式（ClusterResult ベタ）にフォールバック
-	var legacy domain.ClusterResult
-	if err := json.Unmarshal([]byte(raw), &legacy); err != nil {
-		return nil, nil, err
+	// ベタの ClusterResult にフォールバック（現行形式 / 旧々形式）。
+	var cr domain.ClusterResult
+	if err := json.Unmarshal([]byte(raw), &cr); err != nil {
+		return nil, err
 	}
-	return &legacy, nil, nil
+	return &cr, nil
+}
+
+// unmarshalChangedFiles は diff 本文を取り出す。
+// changed_files カラムがあればそこから、無ければ PR-E 形式の result 埋め込みから復元する。
+func unmarshalChangedFiles(resultRaw string, changedCol sql.NullString) ([]domain.DiffFile, error) {
+	if changedCol.Valid {
+		var files []domain.DiffFile
+		if err := json.Unmarshal([]byte(changedCol.String), &files); err != nil {
+			return nil, err
+		}
+		return files, nil
+	}
+	// PR-E 形式: result に changed_files が埋め込まれている。
+	var wrapper analysisResultJSON
+	if err := json.Unmarshal([]byte(resultRaw), &wrapper); err == nil && wrapper.ClusterResult.Graph.Nodes != nil {
+		return wrapper.ChangedFiles, nil
+	}
+	// 旧々形式: diff データ無し。
+	return nil, nil
 }

--- a/backend/internal/infra/store/analysis_repo_test.go
+++ b/backend/internal/infra/store/analysis_repo_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -180,6 +181,167 @@ func TestAnalysisRepo_FindByPR_ReturnsLatest(t *testing.T) {
 	// 永続化された PR メタ情報（SHA）が引数 pr ではなく DB の値で復元されること。
 	if got.PR.HeadSHA != "head789" {
 		t.Errorf("expected persisted HeadSHA, got %q", got.PR.HeadSHA)
+	}
+}
+
+// changed_files を別カラムに分離した現行形式で、Save→FindDiffByID が diff 本文を
+// round-trip すること。かつ FindByID（グラフ経路）は diff 本文を読み込まないこと。
+func TestAnalysisRepo_ChangedFilesRoundTrip(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewAnalysisRepo(db)
+	ctx := context.Background()
+
+	a := &domain.Analysis{
+		ID:     "a1",
+		PR:     domain.PRInfo{Owner: "o", Repo: "r", Number: 1},
+		Result: &domain.ClusterResult{Graph: domain.Graph{Nodes: []domain.Node{{ID: "fn:A"}}}},
+		ChangedFiles: []domain.DiffFile{
+			{Filename: "pkg/a.go", Status: domain.FileStatusAdded, Additions: 3, AfterContent: "package a"},
+		},
+		CreatedAt: time.Now().UTC().Truncate(time.Second),
+	}
+	if err := repo.Save(ctx, a); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// diff 経路: changed_files が返る
+	diff, err := repo.FindDiffByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("FindDiffByID: %v", err)
+	}
+	if diff == nil || len(diff.ChangedFiles) != 1 || diff.ChangedFiles[0].Filename != "pkg/a.go" ||
+		diff.ChangedFiles[0].AfterContent != "package a" {
+		t.Errorf("unexpected diff: %+v", diff)
+	}
+
+	// グラフ経路: Result は返るが diff 本文は読み込まない
+	graph, err := repo.FindByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("FindByID: %v", err)
+	}
+	if graph == nil || len(graph.Result.Graph.Nodes) != 1 {
+		t.Errorf("unexpected graph result: %+v", graph)
+	}
+	if graph.ChangedFiles != nil {
+		t.Errorf("FindByID must not load diff bodies, got %+v", graph.ChangedFiles)
+	}
+}
+
+func TestAnalysisRepo_FindDiffByID_NotFound(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewAnalysisRepo(db)
+	got, err := repo.FindDiffByID(context.Background(), "nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}
+
+// PR-E 世代の行（result に {cluster_result, changed_files} を埋め込み・changed_files
+// カラムは NULL）でも、FindDiffByID が result 埋め込みへフォールバックして diff を返し、
+// FindByID / FindByPR がグラフを正しく復元すること。
+func TestAnalysisRepo_LegacyEmbeddedFormat(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	embedded := analysisResultJSON{
+		ClusterResult: domain.ClusterResult{Graph: domain.Graph{Nodes: []domain.Node{{ID: "fn:A"}}}},
+		ChangedFiles:  []domain.DiffFile{{Filename: "old.go", Status: domain.FileStatusModified}},
+	}
+	raw, err := json.Marshal(embedded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// changed_files カラムを省いた（NULL の）レガシー行を直接挿入する。
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO analyses (id, owner, repo, pr_number, result, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		"legacy", "o", "r", 1, string(raw), time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatalf("insert legacy row: %v", err)
+	}
+
+	repo := NewAnalysisRepo(db)
+
+	diff, err := repo.FindDiffByID(ctx, "legacy")
+	if err != nil {
+		t.Fatalf("FindDiffByID: %v", err)
+	}
+	if diff == nil || len(diff.ChangedFiles) != 1 || diff.ChangedFiles[0].Filename != "old.go" {
+		t.Errorf("legacy diff fallback failed: %+v", diff)
+	}
+
+	graph, err := repo.FindByID(ctx, "legacy")
+	if err != nil {
+		t.Fatalf("FindByID: %v", err)
+	}
+	if graph == nil || len(graph.Result.Graph.Nodes) != 1 || graph.Result.Graph.Nodes[0].ID != "fn:A" {
+		t.Errorf("legacy graph decode failed: %+v", graph)
+	}
+
+	cached, err := repo.FindByPR(ctx, domain.PRInfo{Owner: "o", Repo: "r", Number: 1})
+	if err != nil {
+		t.Fatalf("FindByPR: %v", err)
+	}
+	if cached == nil || len(cached.ChangedFiles) != 1 {
+		t.Errorf("legacy FindByPR must recover changed files: %+v", cached)
+	}
+}
+
+// 旧々形式（result が ClusterResult ベタ・diff 情報なし）でも graph が復元でき、
+// diff は空で返ること。
+func TestAnalysisRepo_LegacyBareFormat(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	raw, err := json.Marshal(domain.ClusterResult{Graph: domain.Graph{Nodes: []domain.Node{{ID: "fn:A"}}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO analyses (id, owner, repo, pr_number, result, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		"bare", "o", "r", 1, string(raw), time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatalf("insert bare row: %v", err)
+	}
+
+	repo := NewAnalysisRepo(db)
+
+	graph, err := repo.FindByID(ctx, "bare")
+	if err != nil {
+		t.Fatalf("FindByID: %v", err)
+	}
+	if graph == nil || len(graph.Result.Graph.Nodes) != 1 {
+		t.Errorf("bare graph decode failed: %+v", graph)
+	}
+
+	diff, err := repo.FindDiffByID(ctx, "bare")
+	if err != nil {
+		t.Fatalf("FindDiffByID: %v", err)
+	}
+	if diff == nil || diff.ChangedFiles != nil {
+		t.Errorf("bare diff should be empty, got %+v", diff)
 	}
 }
 

--- a/backend/internal/infra/store/db.go
+++ b/backend/internal/infra/store/db.go
@@ -57,6 +57,12 @@ func migrate(db *sql.DB) error {
 			return err
 		}
 	}
+	// diff 本文（changed_files）を result から別カラムに分離する。
+	// グラフ読み経路（/api/graph）で diff 本文を unmarshal しないための最適化。
+	// 分離前に保存された行はこのカラムが NULL のまま残り、読み出し側で result 埋め込みへフォールバックする。
+	if err := addColumnIfNotExists(db, "analyses", "changed_files", "TEXT"); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/backend/internal/infra/store/schema.sql
+++ b/backend/internal/infra/store/schema.sql
@@ -9,7 +9,8 @@ CREATE TABLE IF NOT EXISTS analyses (
     pr_head_ref TEXT NOT NULL DEFAULT '',
     pr_base_sha TEXT NOT NULL DEFAULT '',
     pr_head_sha TEXT NOT NULL DEFAULT '',
-    result      TEXT,    -- JSON
+    result      TEXT,    -- ClusterResult の JSON（グラフ本体。diff 本文は含まない）
+    changed_files TEXT,  -- []DiffFile の JSON（diff 本文。グラフ読み経路で unmarshal しないよう別カラムに分離）
     created_at  DATETIME NOT NULL
 );
 

--- a/backend/internal/usecase/analyze_pr_test.go
+++ b/backend/internal/usecase/analyze_pr_test.go
@@ -32,6 +32,10 @@ func (r *fakeAnalysisRepo) FindByID(_ context.Context, id domain.AnalysisID) (*d
 	return r.byID[id], r.err
 }
 
+func (r *fakeAnalysisRepo) FindDiffByID(_ context.Context, id domain.AnalysisID) (*domain.Analysis, error) {
+	return r.byID[id], r.err
+}
+
 func (r *fakeAnalysisRepo) FindByPR(_ context.Context, _ domain.PRInfo) (*domain.Analysis, error) {
 	return r.byPR, r.err
 }

--- a/backend/internal/usecase/get_analysis.go
+++ b/backend/internal/usecase/get_analysis.go
@@ -62,3 +62,28 @@ func (uc *GetAnalysisUseCase) GetGraph(ctx context.Context, id domain.JobID, mod
 	out.Result = applyClusterMode(a.Result, mode)
 	return &out, nil
 }
+
+// GetDiff はジョブに紐づく解析の変更ファイル（diff 本文）を返す。
+// グラフ本体は読み込まない（diff 表示のための軽量経路）。
+// ジョブが存在しない場合は ErrJobNotFound、まだ完了していない場合は ErrJobNotReady を返す。
+func (uc *GetAnalysisUseCase) GetDiff(ctx context.Context, id domain.JobID) (*domain.Analysis, error) {
+	j, err := uc.jobs.FindByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("find job: %w", err)
+	}
+	if j == nil {
+		return nil, ErrJobNotFound
+	}
+	if j.Status != domain.JobStatusDone || j.AnalysisID == "" {
+		return nil, ErrJobNotReady
+	}
+
+	a, err := uc.analyses.FindDiffByID(ctx, j.AnalysisID)
+	if err != nil {
+		return nil, fmt.Errorf("find analysis diff: %w", err)
+	}
+	if a == nil {
+		return nil, fmt.Errorf("data integrity error: job %s is done but analysis %s not found", id, j.AnalysisID)
+	}
+	return a, nil
+}

--- a/backend/internal/usecase/get_analysis_test.go
+++ b/backend/internal/usecase/get_analysis_test.go
@@ -53,6 +53,13 @@ func (r *fakeGetAnalysisRepo) FindByID(_ context.Context, id domain.AnalysisID) 
 	return r.analyses[id], nil
 }
 
+func (r *fakeGetAnalysisRepo) FindDiffByID(_ context.Context, id domain.AnalysisID) (*domain.Analysis, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.analyses[id], nil
+}
+
 func (r *fakeGetAnalysisRepo) FindByPR(_ context.Context, _ domain.PRInfo) (*domain.Analysis, error) {
 	return nil, r.err
 }
@@ -178,6 +185,67 @@ func TestGetGraph_IntegrityError(t *testing.T) {
 	uc := NewGetAnalysisUseCase(analyses, jobs)
 
 	_, err := uc.GetGraph(context.Background(), "j4", domain.ClusterModeLouvain)
+	if err == nil {
+		t.Error("expected error for missing analysis, got nil")
+	}
+}
+
+func TestGetDiff_NotFound(t *testing.T) {
+	jobs := &fakeGetJobRepo{jobs: make(map[domain.JobID]*domain.Job)}
+	analyses := &fakeGetAnalysisRepo{analyses: make(map[domain.AnalysisID]*domain.Analysis)}
+	uc := NewGetAnalysisUseCase(analyses, jobs)
+
+	_, err := uc.GetDiff(context.Background(), "nonexistent")
+	if !errors.Is(err, ErrJobNotFound) {
+		t.Errorf("expected ErrJobNotFound, got %v", err)
+	}
+}
+
+func TestGetDiff_NotReady_Pending(t *testing.T) {
+	jobs := &fakeGetJobRepo{jobs: map[domain.JobID]*domain.Job{
+		"j1": {ID: "j1", Status: domain.JobStatusPending},
+	}}
+	analyses := &fakeGetAnalysisRepo{analyses: make(map[domain.AnalysisID]*domain.Analysis)}
+	uc := NewGetAnalysisUseCase(analyses, jobs)
+
+	_, err := uc.GetDiff(context.Background(), "j1")
+	if !errors.Is(err, ErrJobNotReady) {
+		t.Errorf("expected ErrJobNotReady, got %v", err)
+	}
+}
+
+func TestGetDiff_Success(t *testing.T) {
+	analysis := &domain.Analysis{
+		ID: "a1",
+		ChangedFiles: []domain.DiffFile{
+			{Filename: "pkg/a.go", Status: domain.FileStatusAdded, Additions: 3},
+		},
+	}
+	jobs := &fakeGetJobRepo{jobs: map[domain.JobID]*domain.Job{
+		"j3": {ID: "j3", Status: domain.JobStatusDone, AnalysisID: "a1"},
+	}}
+	analyses := &fakeGetAnalysisRepo{analyses: map[domain.AnalysisID]*domain.Analysis{
+		"a1": analysis,
+	}}
+	uc := NewGetAnalysisUseCase(analyses, jobs)
+
+	got, err := uc.GetDiff(context.Background(), "j3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || len(got.ChangedFiles) != 1 || got.ChangedFiles[0].Filename != "pkg/a.go" {
+		t.Errorf("unexpected diff: %+v", got)
+	}
+}
+
+func TestGetDiff_IntegrityError(t *testing.T) {
+	jobs := &fakeGetJobRepo{jobs: map[domain.JobID]*domain.Job{
+		"j4": {ID: "j4", Status: domain.JobStatusDone, AnalysisID: "missing-analysis"},
+	}}
+	analyses := &fakeGetAnalysisRepo{analyses: make(map[domain.AnalysisID]*domain.Analysis)}
+	uc := NewGetAnalysisUseCase(analyses, jobs)
+
+	_, err := uc.GetDiff(context.Background(), "j4")
 	if err == nil {
 		t.Error("expected error for missing analysis, got nil")
 	}


### PR DESCRIPTION
## 概要

#93 の残タスク（PR-H）。gzip + Cache-Control（#103）に続く後半で、`analyses.result` に混在していた diff 本文（changed_files）を別カラムへ分離し、`/api/graph` の読み出しで diff 本文を unmarshal しないようにする。

## 変更点

- `analyses` に `changed_files TEXT` カラムを追加（`schema.sql` + `addColumnIfNotExists` の冪等 migrate）
- `Save`: ClusterResult を `result` に、`[]DiffFile` を `changed_files` に分離保存（diff 未取得時は NULL）
- `FindByID`（グラフ経路）: `result` のみ読む。**diff 本文は読み込まない**
- `FindDiffByID`（新設・diff 経路）: `changed_files` のみ読む
- `diff_handler` の `GetGraph` 依存を解消 → usecase に `GetDiff` を新設。DiffHandler は diff 用の狭い interface（`diffReadUseCase`）にのみ依存
- 旧形式行のフォールバック互換:
  - PR-E 形式（`result` に `{cluster_result, changed_files}` 埋め込み・`changed_files` カラム NULL）→ 埋め込みから diff を復元
  - 旧々形式（`result` が ClusterResult ベタ）→ diff は空、グラフは正常復元

## テスト

- store: 新形式の round-trip / `FindByID` が diff を読まないこと / PR-E 埋め込みフォールバック / 旧々ベタ形式 / not-found
- usecase: `GetDiff` の NotFound / NotReady / Success / IntegrityError
- api: `DiffHandler` を `GetDiff` 経由に更新
- `gofmt` / `go vet` / `go test ./...` すべてグリーン

## Test plan（レビュアー実施）

- [x] 既存の解析結果（分離前に保存された行）で `/api/graph`・`/api/diff` が従来どおり返ること
- [x] 新規解析後、`/api/graph` と `/api/diff` のレスポンス内容が変更前と一致すること
- [x] gzip と合わせてグラフ JSON の転送量・読み出しレイテンシが改善していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)