### PR TITLE
perf: 近傍パッケージ数を削減しジョブタイムアウトを延長 (#108)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -61,7 +61,7 @@ func main() {
 	queue := job.NewQueue(queueBuf)
 
 	// 1ジョブの解析時間上限。暴走解析がワーカーを占有し続けるのを防ぐ安全弁。
-	jobTimeout := time.Duration(envIntOr("JOB_TIMEOUT_SECONDS", 120)) * time.Second
+	jobTimeout := time.Duration(envIntOr("JOB_TIMEOUT_SECONDS", 180)) * time.Second
 	worker := job.NewWorker(queue, jobRepo, analysisRepo, prRepo, sourceTree, cgBuilder, clusterer,
 		job.WithJobTimeout(jobTimeout))
 

--- a/backend/internal/infra/analyzer/source_tree.go
+++ b/backend/internal/infra/analyzer/source_tree.go
@@ -18,7 +18,13 @@ import (
 // defaultMaxNeighborhood は Phase 2 で型情報付きロードする近傍パッケージ数の上限。
 // これを超える近傍は近いホップ優先で打ち切る。k8s のようなハブパッケージを含む
 // 巨大リポジトリでフルロードがメモリ枯渇するのを防ぐためのガード。
-const defaultMaxNeighborhood = 500
+// terraform（178 pkgs）で170近傍→タイムアウトした実測値から 150 に設定。
+const defaultMaxNeighborhood = 150
+
+// defaultNeighborhoodDepth はパッケージ近傍を辿る import グラフ上のホップ数上限。
+// callgraph BFS の defaultMaxDepth（関数レベル）とは独立。ハブパッケージを含む
+// リポジトリでは depth=3 で全パッケージに到達してしまうため 2 に抑える。
+const defaultNeighborhoodDepth = 2
 
 // PreparedSource はclone・ロード・変更パッケージ特定の結果をまとめたもの。
 type PreparedSource struct {
@@ -161,7 +167,7 @@ func (s *SourceTree) prepareFromDir(ctx context.Context, rootDir string, changed
 	// 型チェックの依存として読まれるが返却パッケージには含まれない。
 	// 件数を上限で抑えるのは、ハブパッケージを含む PR（k8s 等）で近傍が数千件に
 	// 膨らみ、フルロード時にメモリ枯渇（OOM）するのを防ぐため。
-	neighborhood := FindNeighborhood(changedPkgs, fastPkgs, defaultMaxDepth, defaultMaxNeighborhood)
+	neighborhood := FindNeighborhood(changedPkgs, fastPkgs, defaultNeighborhoodDepth, defaultMaxNeighborhood)
 	if len(neighborhood) >= defaultMaxNeighborhood {
 		log.Printf("analyzer: neighborhood capped at %d pkgs (changed=%d) — graph may be partial", defaultMaxNeighborhood, len(changedPkgs))
 	}

--- a/backend/internal/infra/job/worker.go
+++ b/backend/internal/infra/job/worker.go
@@ -35,7 +35,7 @@ type sourceTreePreparer interface {
 // defaultJobTimeout は1ジョブの解析にかける時間の上限のデフォルト値。
 // 巨大リポジトリ（k8s 等）の解析が暴走してワーカーを無限に占有し、
 // 後続ジョブ（＝他ユーザー）を巻き添えにするのを防ぐ安全弁。
-const defaultJobTimeout = 120 * time.Second
+const defaultJobTimeout = 180 * time.Second
 
 // Worker はキューからジョブを受け取り解析パイプラインを実行する。
 // Run は複数 goroutine から同時に呼び出して構わない（フィールドは不変、


### PR DESCRIPTION
## Summary

- terraform OSS（178 pkgs）の PR 解析で、ハブパッケージ（`addrs`, `terraform`）が depth=3 でほぼ全パッケージ（170/178）を近傍に取り込み、Phase 2 の型付きロードが 120s のジョブタイムアウト内に完了しなかった問題を修正
- パッケージ近傍の depth を 3→2 に下げ、callgraph BFS の `defaultMaxDepth` と独立した定数 `defaultNeighborhoodDepth` として分離
- `defaultMaxNeighborhood` を 500→150 に削減し、Phase 2 のロード対象パッケージ数を直接制限
- `defaultJobTimeout` を 120s→180s に延長（`JOB_TIMEOUT_SECONDS` env のデフォルトも同期）

## Test plan

- [x] `go vet ./...` グリーン
- [x] `go test ./...` 全パス
- [x] terraform の PR（例: hashicorp/terraform の小〜中規模 PR）を投げてタイムアウトせず完走するか確認
- [x] 既存の中規模リポジトリ（gin 等）で結果が欠落しないか確認
- [ ] `JOB_TIMEOUT_SECONDS=300` を env に設定し、設定値が反映されるか確認

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)