### PR TITLE
LP を実装に合わせる + GraphControls デザイン刷新

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -150,7 +150,7 @@ ID やファイルパスは必ず mono にする。視認性と「これはコ�
 | `SuperClusterNode` | 折りたたみ中クラスタのスーパーノード。クリックで展開 |
 | `FunctionDetailsPanel` | 右パネル。クラスタラベル・レイヤー・GitHub 該当行リンク・diff |
 | `GraphSearch` | グラフ左上の検索ボックス。関数名/パッケージをインクリメンタル検索→候補選択で展開+選択+中央寄せ（`fitView`）。折りたたみ中クラスタ内のノードも親を開いて到達する |
-| `GraphControls` | 右下コントロールパネル。表示モード切替・クラスタモード・展開/折りたたみ・変更ノードステップナビゲーター（`[←] 3/12 変更 [→]`）。ナビゲーターはレビュー優先度順に変更ノードを1つずつ巡回し、クラスタ自動展開+選択+中央寄せを行う |
+| `GraphControls` | 右下フローティングパネル（frosted glass: `bg-white/90 backdrop-blur-md`）。ラベル付きセクションに分割: 表示モード切替（変更影響/全体）・クラスタモード（Louvain/Package/File）・展開/折畳アクションボタン・変更ノードステップナビゲーター。セグメントコントロールは pill 型（active=`bg-white shadow-sm`、inactive=`text-stone-500`）。ナビゲーターはレビュー優先度順に変更ノードを1つずつ巡回し、クラスタ自動展開+選択+中央寄せを行う |
 | `FocusLegend` | フォーカスモード中に左上（検索ボックスの下）に出る凡例（呼び出し元/先の方向色と件数） |
 | `DiffViewer` | `@monaco-editor/react` で before/after 表示 |
 | `ClusterSidebar` | クラスタ一覧（実装位置: `layout/`） |
@@ -192,9 +192,13 @@ ID やファイルパスは必ず mono にする。視認性と「これはコ�
 
 - **認証で出し分け**: Hero と CTA strip は `useAuth()` を見て切替える。未ログイン → GitHub 連携ボタン（`/auth/github`）、ログイン済み → PR URL 入力フォーム（`PrInputForm`、`useAnalyzeMutation` + `parsePrUrl` に接続し `/analysis/:jobId` へ遷移）。
 - **ルート**: `/`=LP（公開） / `/analyze`=PR 入力 Home（要認証） / `/analysis/:jobId`=結果（要認証） / `/login`。`RequireAuth` から外れる公開ページは `/` のみ。
-- **実装**: Claude Design の handoff（`design/project/landing.jsx`）を Tailwind ユーティリティで再現。handoff の色は Tailwind 標準パレットにそのまま対応する（中立色=`stone`、ブランド=`teal`、4 クラスタ=`green`/`red`/`amber`/`violet` の 600/100/300）。ボタンと入力欄は shadcn/ui の `Button`（`asChild` でリンク化）/ `Input` を流用。中央寄せコンテナは `components/landing/Wrap.tsx` に共通化。レスポンシブは Tailwind の `sm:`/`lg:` と `clamp()`（見出し）で担保。装飾の radial-gradient/mask とグラフ系 SVG の配色のみ inline style / リテラル hex（グラフ意味色の慣習に準拠）。
+- **実装**: Claude Design の handoff（`design/project/landing.jsx`）を Tailwind ユーティリティで再現。handoff の色は Tailwind 標準パレットにそのまま対応する（中立色=`stone`、ブランド=`teal`）。ボタンと入力欄は shadcn/ui の `Button`（`asChild` でリンク化）/ `Input` を流用。中央寄せコンテナは `components/landing/Wrap.tsx` に共通化。レスポンシブは Tailwind の `sm:`/`lg:` と `clamp()`（見出し）で担保。装飾の radial-gradient/mask とグラフ系 SVG の配色のみ inline style / リテラル hex（グラフ意味色の慣習に準拠）。
 - **プロダクトマーク**: `components/branding/AppMark.tsx` が diffmap. のアプリアイコン（design "A4·4"：ノード群が 1 つの accent ノードへ V 字で収束する形）。`Brand.tsx` と `public/favicon.svg` もこれに統一。
-- **データ整合**: 「最近の解析」一覧は対応するバックエンド API が未実装のため、handoff のダミーは載せず省略している（4 状態原則・データ捏造回避）。実装後に追加する。Hero の統計値（解析数・短縮率など）は handoff のマーケコピーをそのまま採用。
+- **コンテンツ整合方針**: LP の記述は実装済み機能に限定する。未実装機能・架空の統計値・存在しないプラン/ページへのリンクは載せない。
+  - `ClusterShowcase`: 実際の 3 クラスタリングモード（Louvain / パッケージ / ファイル）を紹介
+  - `FeatureGrid`: 影響範囲 hop 可視化・AST diff・新規循環参照検出の 3 機能
+  - `HowItWorks`: PR 貼付 → 依存グラフ構築 → クラスタ構造把握の 3 ステップ
+  - Footer: 実リンクのみ（GitHub / README / ページ内アンカー）
 
 ---
 

--- a/design/project/landing.jsx
+++ b/design/project/landing.jsx
@@ -4,7 +4,6 @@ const { useState } = React;
 
 const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
   "authState": "guest",
-  "showHistory": true,
   "ctaTone": "ink"
 }/*EDITMODE-END*/;
 
@@ -71,7 +70,7 @@ function Nav({ authState }) {
         <div style={{ display: "flex", alignItems: "center", gap: 28, fontSize: 13, color: "var(--ink-2)" }}>
           <a style={navLinkStyle}>機能</a>
           <a style={navLinkStyle}>仕組み</a>
-          <a style={navLinkStyle}>ドキュメント</a>
+          <a style={navLinkStyle}>クラスタリング</a>
           <a style={navLinkStyle} href="#"><GitHubGlyph size={13} /> GitHub</a>
           <div style={{ width: 1, height: 18, background: "var(--line)" }} />
           {authState === "guest" ? (
@@ -125,7 +124,7 @@ function Hero({ authState, ctaTone }) {
             プルリクを、<br/><span style={{ color: "var(--brand)" }}>構造</span>として読む。
           </h1>
           <p style={{ fontSize: 17, lineHeight: 1.6, color: "var(--ink-2)", margin: "0 0 32px", maxWidth: 500 }}>
-            変更ファイルの羅列ではなく、モジュールの依存関係として PR を可視化。100 ファイル超のレビューも、4 つの意味のあるクラスタに自動分割します。
+            変更ファイルの羅列ではなく、モジュールの依存関係として PR を可視化。大規模レビューも、意味のあるクラスタに自動分割します。
           </p>
 
           {/* === Auth-aware CTA === */}
@@ -134,15 +133,6 @@ function Hero({ authState, ctaTone }) {
           ) : (
             <PrInputCTA />
           )}
-
-          {/* social proof */}
-          <div style={{ marginTop: 40, display: "flex", gap: 28, alignItems: "center" }}>
-            <Stat n="2,400+" l="解析された PR" />
-            <div style={{ width: 1, height: 32, background: "var(--line)" }} />
-            <Stat n="38%" l="レビュー時間短縮" />
-            <div style={{ width: 1, height: 32, background: "var(--line)" }} />
-            <Stat n="< 5s" l="平均解析時間" />
-          </div>
         </div>
 
         <HeroIllustration />
@@ -152,15 +142,6 @@ function Hero({ authState, ctaTone }) {
 }
 
 const pillStyle = { display: "inline-flex", alignItems: "center", gap: 8, padding: "6px 12px", background: "var(--brand-soft)", color: "var(--brand-ink)", borderRadius: 99, fontSize: 12, fontWeight: 500, border: "1px solid #99f6e4" };
-
-function Stat({ n, l }) {
-  return (
-    <div>
-      <div style={{ fontSize: 22, fontWeight: 600, color: "var(--ink)", fontVariantNumeric: "tabular-nums", letterSpacing: "-0.02em" }}>{n}</div>
-      <div style={{ fontSize: 12, color: "var(--ink-3)", marginTop: 2 }}>{l}</div>
-    </div>
-  );
-}
 
 // ──────────────────────────────────────────────────────────────────────
 // CTA — Guest (GitHub OAuth)
@@ -268,12 +249,6 @@ function PrInputCTA() {
           )}
         </form>
       </div>
-      <div style={{ display: "flex", alignItems: "center", gap: 10, fontSize: 12, color: "var(--ink-3)" }}>
-        <span>最近の解析:</span>
-        {["#1278", "#1262", "#1241"].map((p) => (
-          <a key={p} className="mono" style={{ color: "var(--ink-2)", textDecoration: "none", padding: "3px 8px", background: "white", border: "1px solid var(--line)", borderRadius: 6, cursor: "pointer" }}>kobold/checkout-service{p}</a>
-        ))}
-      </div>
     </div>
   );
 }
@@ -352,10 +327,10 @@ function HeroIllustration() {
         <div style={{ borderTop: "1px solid var(--line)", padding: "10px 14px", display: "flex", justifyContent: "space-between", alignItems: "center", background: "var(--bg-alt)" }}>
           <div style={{ display: "flex", gap: 14, fontSize: 11 }}>
             {[
-              ["#16a34a", "追加 3"],
-              ["#dc2626", "削除 1"],
-              ["#d97706", "修正 3"],
-              ["#7c3aed", "リファクタ 2"],
+              ["#16a34a", "Cluster A"],
+              ["#dc2626", "Cluster B"],
+              ["#d97706", "Cluster C"],
+              ["#7c3aed", "Cluster D"],
             ].map(([c, l]) => (
               <span key={l} style={{ display: "inline-flex", alignItems: "center", gap: 5, color: "var(--ink-2)" }}>
                 <span style={{ width: 8, height: 8, borderRadius: 2, background: c }} />
@@ -366,37 +341,35 @@ function HeroIllustration() {
           <span className="mono" style={{ fontSize: 10, color: "var(--ink-3)" }}>2.4s</span>
         </div>
       </div>
-
-      {/* (annotation removed — graph + legend speak for themselves) */}
     </div>
   );
 }
 
 // ──────────────────────────────────────────────────────────────────────
-// Section · 4-way cluster
+// Section · Smart Clustering
 // ──────────────────────────────────────────────────────────────────────
 
 function ClusterSection() {
-  const clusters = [
-    { label: "追加",       desc: "新規モジュール",         c: "var(--added)",    bg: "var(--added-bg)",    bd: "var(--added-bd)",    icon: "+", n: 11 },
-    { label: "削除",       desc: "削除されたモジュール",   c: "var(--removed)",  bg: "var(--removed-bg)",  bd: "var(--removed-bd)",  icon: "−", n: 4 },
-    { label: "修正",       desc: "ロジック変更を含む",     c: "var(--modified)", bg: "var(--modified-bg)", bd: "var(--modified-bd)", icon: "~", n: 13 },
-    { label: "リファクタ", desc: "振る舞い保存・構造変更", c: "var(--refactor)", bg: "var(--refactor-bg)", bd: "var(--refactor-bd)", icon: "↻", n: 6 },
+  const modes = [
+    { label: "Louvain",       desc: "依存関係の密度からコミュニティを自動検出",   icon: "{}", badge: "既定" },
+    { label: "パッケージ",     desc: "Go パッケージ単位でグルーピング",         icon: "/",  badge: "" },
+    { label: "ファイル",       desc: "ソースファイル単位でグルーピング",         icon: "[]", badge: "" },
   ];
   return (
-    <section id="how" style={{ padding: "112px 0 88px", borderBottom: "1px solid var(--line)" }}>
+    <section id="showcase" style={{ padding: "112px 0 88px", borderBottom: "1px solid var(--line)" }}>
       <div className="wrap">
-        <SectionHead eyebrow="4-way auto cluster" title="変更の種類で、自動的に4つに分ける。" lead="ファイル名やパスではなく、AST と呼び出しグラフから「変更の意味」を抽出。レビュアーは色とまとまりで読み進められます。" />
-        <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 16, marginTop: 48 }}>
-          {clusters.map((k) => (
-            <div key={k.label} style={{ background: "white", border: "1px solid var(--line)", borderRadius: 14, padding: 22, position: "relative", overflow: "hidden" }}>
-              <div style={{ position: "absolute", inset: "0 auto 0 0", width: 3, background: k.c }} />
+        <SectionHead eyebrow="Smart clustering" title="依存関係から、自動でクラスタを生成。" lead="Louvain アルゴリズムが呼び出しグラフのコミュニティ構造を検出し、関連する関数群を意味のあるまとまりに自動分割。パッケージ・ファイル単位への切替もワンクリック。" />
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 16, marginTop: 48 }}>
+          {modes.map((m) => (
+            <div key={m.label} style={{ background: "white", border: "1px solid var(--line)", borderRadius: 14, padding: 22, position: "relative", overflow: "hidden" }}>
               <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-                <div style={{ width: 38, height: 38, borderRadius: 10, background: k.bg, border: `1px solid ${k.bd}`, display: "flex", alignItems: "center", justifyContent: "center", color: k.c, fontWeight: 600, fontSize: 18 }}>{k.icon}</div>
-                <div className="mono" style={{ fontSize: 11, color: "var(--ink-3)" }}>n={k.n}</div>
+                <div className="mono" style={{ width: 38, height: 38, borderRadius: 10, background: "var(--brand-soft)", border: "1px solid #99f6e4", display: "flex", alignItems: "center", justifyContent: "center", color: "var(--brand)", fontWeight: 600, fontSize: 14 }}>{m.icon}</div>
+                {m.badge && (
+                  <span style={{ fontSize: 10, fontWeight: 500, color: "var(--brand)", background: "var(--brand-soft)", padding: "2px 8px", borderRadius: 99 }}>{m.badge}</span>
+                )}
               </div>
-              <div style={{ fontSize: 16, fontWeight: 600, color: "var(--ink)", marginTop: 16, letterSpacing: "-0.01em" }}>{k.label}</div>
-              <div style={{ fontSize: 13, color: "var(--ink-3)", marginTop: 4, lineHeight: 1.5 }}>{k.desc}</div>
+              <div style={{ fontSize: 16, fontWeight: 600, color: "var(--ink)", marginTop: 16, letterSpacing: "-0.01em" }}>{m.label}</div>
+              <div style={{ fontSize: 13, color: "var(--ink-3)", marginTop: 4, lineHeight: 1.5 }}>{m.desc}</div>
             </div>
           ))}
         </div>
@@ -425,8 +398,8 @@ function HowItWorks() {
     },
     {
       n: "03",
-      title: "クラスタごとに読む",
-      desc: "追加 → 修正 → リファクタ → 削除 の順に、レビュアーの認知に沿った読み方を提案します。",
+      title: "クラスタで構造を把握",
+      desc: "Louvain アルゴリズムが関連する関数群をクラスタに自動分割。変更ノードを優先度順にナビゲートして効率的にレビュー。",
       mock: <StepMock3 />,
     },
   ];
@@ -497,21 +470,27 @@ function StepMock2() {
 
 function StepMock3() {
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 6, width: "100%" }}>
+    <svg viewBox="0 0 220 140" style={{ width: "100%" }}>
+      <rect x="14" y="10" width="92" height="52" rx="8" fill="#f0fdfa" stroke="#99f6e4" strokeDasharray="3 2"/>
+      <rect x="124" y="10" width="82" height="52" rx="8" fill="#f5f3ff" stroke="#c4b5fd" strokeDasharray="3 2"/>
+      <rect x="69" y="74" width="82" height="52" rx="8" fill="#fffbeb" stroke="#fcd34d" strokeDasharray="3 2"/>
       {[
-        ["追加", "var(--added)", "var(--added-bg)", "var(--added-bd)", 70],
-        ["修正", "var(--modified)", "var(--modified-bg)", "var(--modified-bd)", 90],
-        ["リファクタ", "var(--refactor)", "var(--refactor-bg)", "var(--refactor-bd)", 45],
-        ["削除", "var(--removed)", "var(--removed-bg)", "var(--removed-bd)", 30],
-      ].map(([lbl, c, bg, bd, w]) => (
-        <div key={lbl} style={{ display: "flex", alignItems: "center", gap: 8 }}>
-          <span style={{ width: 64, fontSize: 11, color: "var(--ink-2)" }}>{lbl}</span>
-          <div style={{ flex: 1, height: 10, background: bg, border: `1px solid ${bd}`, borderRadius: 99, overflow: "hidden" }}>
-            <div style={{ width: `${w}%`, height: "100%", background: c, opacity: 0.85 }} />
-          </div>
-        </div>
+        {x:20, y:16, label:"Cluster A", color:"#0f766e"},
+        {x:130, y:16, label:"Cluster B", color:"#7c3aed"},
+        {x:75, y:80, label:"Cluster C", color:"#d97706"},
+      ].map((n) => (
+        <g key={n.label}>
+          <circle cx={n.x+20} cy={n.y+22} r="6" fill={n.color}/>
+          <circle cx={n.x+38} cy={n.y+18} r="4" fill={n.color} opacity="0.6"/>
+          <circle cx={n.x+52} cy={n.y+26} r="5" fill={n.color} opacity="0.8"/>
+          <text x={n.x+36} y={n.y+44} textAnchor="middle" fontSize="8" fill="#78716c" fontFamily="Inter Tight">{n.label}</text>
+        </g>
       ))}
-    </div>
+      <g stroke="#d6d3d1" strokeWidth="1" fill="none">
+        <path d="M60 50 Q80 68 90 80"/>
+        <path d="M150 58 Q140 68 130 80"/>
+      </g>
+    </svg>
   );
 }
 
@@ -542,8 +521,8 @@ function Features() {
       art: <FeatureArt2 />,
     },
     {
-      title: "コメントは AST に紐づく",
-      desc: "rebase してもコメントが迷子にならない。ノード単位で議論を継続できます。",
+      title: "新規循環参照を自動検出",
+      desc: "PR で新たに生じた循環依存を赤でハイライト。構造リスクをレビュー前に把握できます。",
       art: <FeatureArt3 />,
     },
   ];
@@ -595,20 +574,23 @@ function FeatureArt2() {
 function FeatureArt3() {
   return (
     <svg viewBox="0 0 200 120" style={{ width: "100%", height: "100%" }}>
-      <rect x="20" y="20" width="100" height="80" rx="8" fill="white" stroke="var(--line-strong)"/>
-      <text x="30" y="38" fontSize="9" fill="var(--ink-3)" fontFamily="JetBrains Mono">func Charge()</text>
-      <rect x="30" y="46" width="80" height="2" fill="var(--ink-3)" opacity="0.2"/>
-      <rect x="30" y="52" width="60" height="2" fill="var(--ink-3)" opacity="0.2"/>
-      <rect x="30" y="58" width="70" height="2" fill="var(--ink-3)" opacity="0.2"/>
-      <path d="M120 60 L150 40" stroke="var(--brand)" strokeWidth="1.5"/>
-      <g>
-        <rect x="140" y="20" width="50" height="36" rx="8" fill="var(--brand)"/>
-        <circle cx="151" cy="32" r="3" fill="white"/>
-        <rect x="158" y="30" width="22" height="2" fill="white" opacity="0.7"/>
-        <rect x="158" y="34" width="18" height="2" fill="white" opacity="0.7"/>
-        <rect x="158" y="38" width="20" height="2" fill="white" opacity="0.7"/>
-        <text x="146" y="50" fontSize="7" fill="white" opacity="0.8" fontFamily="JetBrains Mono">@ shimo-dev</text>
+      <g stroke="#d6d3d1" strokeWidth="1" fill="none">
+        <path d="M60 30 L100 60"/>
+        <path d="M140 30 L100 60"/>
+        <path d="M100 60 L60 90"/>
+        <path d="M100 60 L140 90"/>
       </g>
+      <rect x="40" y="18" width="40" height="24" rx="4" fill="white" stroke="#d6d3d1"/>
+      <text x="60" y="34" textAnchor="middle" fontSize="8" fill="#44403c" fontFamily="JetBrains Mono">funcA</text>
+      <rect x="120" y="18" width="40" height="24" rx="4" fill="white" stroke="#d6d3d1"/>
+      <text x="140" y="34" textAnchor="middle" fontSize="8" fill="#44403c" fontFamily="JetBrains Mono">funcB</text>
+      <circle cx="100" cy="60" r="14" fill="#ef4444"/>
+      <text x="100" y="64" textAnchor="middle" fontSize="8" fill="white" fontFamily="JetBrains Mono" fontWeight="600">↻</text>
+      <rect x="40" y="78" width="40" height="24" rx="4" fill="white" stroke="#d6d3d1"/>
+      <text x="60" y="94" textAnchor="middle" fontSize="8" fill="#44403c" fontFamily="JetBrains Mono">funcC</text>
+      <rect x="120" y="78" width="40" height="24" rx="4" fill="#fee2e2" stroke="#fca5a5"/>
+      <text x="140" y="94" textAnchor="middle" fontSize="8" fill="#dc2626" fontFamily="JetBrains Mono">funcD</text>
+      <path d="M140 78 L100 74" stroke="#ef4444" strokeWidth="2" fill="none"/>
     </svg>
   );
 }
@@ -628,7 +610,7 @@ function CTAStrip({ authState }) {
             <span style={{ color: "var(--brand-light)" }}>構造を読もう。</span>
           </h2>
           <p style={{ fontSize: 16, color: "rgba(255,255,255,0.65)", margin: "0 0 32px", maxWidth: 480, lineHeight: 1.6 }}>
-            GitHub と連携して 30 秒で開始。公開リポジトリは無料、Pro プラン招待ベータ受付中。
+            GitHub と連携するだけですぐに使えます。パブリックリポジトリは無料で解析可能。
           </p>
           {authState === "guest" ? (
             <a href="/auth/github" style={{ ...btn, background: "white", color: "var(--ink)", height: 52, padding: "0 22px", fontSize: 15, textDecoration: "none", boxShadow: "0 4px 14px rgba(0,0,0,0.25)" }}>
@@ -655,13 +637,12 @@ function CTAStrip({ authState }) {
 
 function Footer() {
   const cols = [
-    { title: "プロダクト", links: ["機能", "仕組み", "料金", "ロードマップ", "変更履歴"] },
-    { title: "ドキュメント", links: ["はじめに", "API リファレンス", "セルフホスト", "CLI"] },
-    { title: "会社", links: ["About", "ブログ", "お問い合わせ", "プレスキット"] },
+    { title: "プロダクト", links: [{ label: "機能", href: "#features" }, { label: "仕組み", href: "#how" }] },
+    { title: "リソース", links: [{ label: "GitHub" }, { label: "README" }] },
   ];
   return (
     <footer style={{ padding: "72px 0 40px", background: "white", borderTop: "1px solid var(--line)" }}>
-      <div className="wrap" style={{ display: "grid", gridTemplateColumns: "1.4fr repeat(3, 1fr)", gap: 48 }}>
+      <div className="wrap" style={{ display: "grid", gridTemplateColumns: "1.6fr repeat(2, 1fr)", gap: 48 }}>
         <div>
           <Brand size={16} />
           <p style={{ fontSize: 13, color: "var(--ink-3)", margin: "14px 0 20px", lineHeight: 1.6, maxWidth: 280 }}>
@@ -672,9 +653,6 @@ function Footer() {
               <GitHubGlyph size={12} />
               GitHub
             </a>
-            <a style={{ ...btnGhost, ...btn, height: 32, padding: "0 12px", fontSize: 12 }}>
-              ドキュメント
-            </a>
           </div>
         </div>
         {cols.map((c) => (
@@ -682,7 +660,7 @@ function Footer() {
             <div style={{ fontSize: 12, fontWeight: 600, color: "var(--ink-2)", marginBottom: 12, letterSpacing: "-0.005em" }}>{c.title}</div>
             <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 8 }}>
               {c.links.map((l) => (
-                <li key={l}><a style={{ fontSize: 13, color: "var(--ink-3)", textDecoration: "none", cursor: "pointer" }}>{l}</a></li>
+                <li key={l.label}><a href={l.href} style={{ fontSize: 13, color: "var(--ink-3)", textDecoration: "none", cursor: "pointer" }}>{l.label}</a></li>
               ))}
             </ul>
           </div>

--- a/frontend/src/components/graph/GraphControls.tsx
+++ b/frontend/src/components/graph/GraphControls.tsx
@@ -38,6 +38,8 @@ function SegmentedControl<T extends string | boolean>({
       {items.map((m) => (
         <button
           key={String(m.value)}
+          type="button"
+          aria-pressed={value === m.value}
           className={[
             'flex-1 rounded-md px-2.5 py-1 text-[11px] font-medium transition-all',
             value === m.value
@@ -56,17 +58,21 @@ function SegmentedControl<T extends string | boolean>({
 function IconButton({
   onClick,
   label,
+  disabled,
   children,
 }: {
   onClick: () => void
   label: string
+  disabled?: boolean
   children: React.ReactNode
 }) {
   return (
     <button
-      className="flex size-7 items-center justify-center rounded-md text-stone-500 transition-colors hover:bg-stone-100 hover:text-stone-700"
+      type="button"
+      className="flex size-7 items-center justify-center rounded-md text-stone-500 transition-colors hover:bg-stone-100 hover:text-stone-700 disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-stone-500"
       onClick={onClick}
       aria-label={label}
+      disabled={disabled}
     >
       {children}
     </button>
@@ -111,6 +117,7 @@ export default function GraphControls({
 
       <div className="flex gap-1">
         <button
+          type="button"
           className="flex h-7 flex-1 items-center justify-center gap-1 rounded-md text-[11px] font-medium text-stone-600 transition-colors hover:bg-stone-100 hover:text-stone-900"
           onClick={onExpandAll}
         >
@@ -131,6 +138,7 @@ export default function GraphControls({
         </button>
         <div className="w-px bg-stone-100" />
         <button
+          type="button"
           className="flex h-7 flex-1 items-center justify-center gap-1 rounded-md text-[11px] font-medium text-stone-600 transition-colors hover:bg-stone-100 hover:text-stone-900"
           onClick={onCollapseAll}
         >

--- a/frontend/src/components/graph/GraphControls.tsx
+++ b/frontend/src/components/graph/GraphControls.tsx
@@ -1,6 +1,4 @@
 import type { ClusterMode } from '@/types/api'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
 
 type Props = {
   clusterMode: ClusterMode
@@ -17,14 +15,63 @@ type Props = {
 
 const CLUSTER_MODES: { value: ClusterMode; label: string }[] = [
   { value: 'louvain', label: 'Louvain' },
-  { value: 'package', label: 'パッケージ' },
-  { value: 'file', label: 'ファイル' },
+  { value: 'package', label: 'Package' },
+  { value: 'file', label: 'File' },
 ]
 
 const VIEW_MODES: { value: boolean; label: string }[] = [
-  { value: true, label: '変更影響のみ' },
+  { value: true, label: '変更影響' },
   { value: false, label: '全体' },
 ]
+
+function SegmentedControl<T extends string | boolean>({
+  items,
+  value,
+  onChange,
+}: {
+  items: { value: T; label: string }[]
+  value: T
+  onChange: (v: T) => void
+}) {
+  return (
+    <div className="flex rounded-lg bg-stone-100 p-0.5">
+      {items.map((m) => (
+        <button
+          key={String(m.value)}
+          className={[
+            'flex-1 rounded-md px-2.5 py-1 text-[11px] font-medium transition-all',
+            value === m.value
+              ? 'bg-white text-stone-900 shadow-sm'
+              : 'text-stone-500 hover:text-stone-700',
+          ].join(' ')}
+          onClick={() => onChange(m.value)}
+        >
+          {m.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function IconButton({
+  onClick,
+  label,
+  children,
+}: {
+  onClick: () => void
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      className="flex size-7 items-center justify-center rounded-md text-stone-500 transition-colors hover:bg-stone-100 hover:text-stone-700"
+      onClick={onClick}
+      aria-label={label}
+    >
+      {children}
+    </button>
+  )
+}
 
 export default function GraphControls({
   clusterMode,
@@ -39,105 +86,116 @@ export default function GraphControls({
   onCollapseAll,
 }: Props) {
   return (
-    <Card className="shadow-md border-stone-200 bg-white">
-      <CardContent className="p-2 flex flex-col gap-2">
-        <div className="flex overflow-hidden rounded border border-stone-200 text-xs">
-          {VIEW_MODES.map((m, i) => (
-            <button
-              key={String(m.value)}
-              className={[
-                'flex-1 px-2 py-1.5 transition-colors',
-                i > 0 ? 'border-l border-stone-200' : '',
-                impactOnly === m.value
-                  ? 'bg-stone-900 text-white'
-                  : 'bg-white text-stone-600 hover:bg-stone-50',
-              ].join(' ')}
-              onClick={() => onSetImpactOnly(m.value)}
-            >
-              {m.label}
-            </button>
-          ))}
+    <div className="flex flex-col gap-2.5 rounded-xl border border-stone-200/60 bg-white/90 p-2.5 shadow-lg shadow-stone-950/[.06] backdrop-blur-md">
+      <div>
+        <div className="mb-1 px-0.5 text-[10px] font-medium tracking-wider text-stone-400">
+          表示
         </div>
-        <div className="flex overflow-hidden rounded border border-stone-200 text-xs">
-          {CLUSTER_MODES.map((m, i) => (
-            <button
-              key={m.value}
-              className={[
-                'flex-1 px-2 py-1.5 transition-colors',
-                i > 0 ? 'border-l border-stone-200' : '',
-                clusterMode === m.value
-                  ? 'bg-stone-900 text-white'
-                  : 'bg-white text-stone-600 hover:bg-stone-50',
-              ].join(' ')}
-              onClick={() => onChangeClusterMode(m.value)}
-            >
-              {m.label}
-            </button>
-          ))}
+        <SegmentedControl items={VIEW_MODES} value={impactOnly} onChange={onSetImpactOnly} />
+      </div>
+
+      <div className="h-px bg-stone-100" />
+
+      <div>
+        <div className="mb-1 px-0.5 text-[10px] font-medium tracking-wider text-stone-400">
+          クラスタ
         </div>
-        <div className="flex gap-1">
-          <Button variant="outline" size="sm" className="h-7 flex-1 text-xs" onClick={onExpandAll}>
-            すべて展開
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-7 flex-1 text-xs"
-            onClick={onCollapseAll}
+        <SegmentedControl
+          items={CLUSTER_MODES}
+          value={clusterMode}
+          onChange={onChangeClusterMode}
+        />
+      </div>
+
+      <div className="h-px bg-stone-100" />
+
+      <div className="flex gap-1">
+        <button
+          className="flex h-7 flex-1 items-center justify-center gap-1 rounded-md text-[11px] font-medium text-stone-600 transition-colors hover:bg-stone-100 hover:text-stone-900"
+          onClick={onExpandAll}
+        >
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 12 12"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            aria-hidden="true"
           >
-            折りたたむ
-          </Button>
-        </div>
-        {changedCount > 0 && (
+            <path d="M2 4.5L6 1.5L10 4.5" />
+            <path d="M2 7.5L6 10.5L10 7.5" />
+          </svg>
+          展開
+        </button>
+        <div className="w-px bg-stone-100" />
+        <button
+          className="flex h-7 flex-1 items-center justify-center gap-1 rounded-md text-[11px] font-medium text-stone-600 transition-colors hover:bg-stone-100 hover:text-stone-900"
+          onClick={onCollapseAll}
+        >
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 12 12"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            aria-hidden="true"
+          >
+            <path d="M2 2L6 5L10 2" />
+            <path d="M2 10L6 7L10 10" />
+          </svg>
+          折畳
+        </button>
+      </div>
+
+      {changedCount > 0 && (
+        <>
+          <div className="h-px bg-stone-100" />
           <div className="flex items-center gap-1">
-            <Button
-              variant="outline"
-              size="icon"
-              className="size-7"
-              onClick={onPrevChanged}
-              aria-label="前の変更ノード"
-            >
+            <IconButton onClick={onPrevChanged} label="前の変更ノード">
               <svg
-                width="12"
-                height="12"
-                viewBox="0 0 12 12"
+                width="10"
+                height="10"
+                viewBox="0 0 10 10"
                 fill="none"
                 stroke="currentColor"
-                strokeWidth="2"
+                strokeWidth="1.5"
                 strokeLinecap="round"
                 strokeLinejoin="round"
                 aria-hidden="true"
               >
-                <path d="M7.5 2.5L4 6l3.5 3.5" />
+                <path d="M6.5 1.5L3 5l3.5 3.5" />
               </svg>
-            </Button>
-            <span className="flex-1 text-center text-xs tabular-nums text-stone-600">
-              {changedIndex !== null ? changedIndex + 1 : '-'} / {changedCount} 変更
-            </span>
-            <Button
-              variant="outline"
-              size="icon"
-              className="size-7"
-              onClick={onNextChanged}
-              aria-label="次の変更ノード"
-            >
+            </IconButton>
+            <div className="flex flex-1 items-center justify-center gap-1.5">
+              <span className="text-[11px] tabular-nums text-stone-900">
+                {changedIndex !== null ? changedIndex + 1 : '-'}
+              </span>
+              <span className="text-[10px] text-stone-400">/</span>
+              <span className="text-[11px] tabular-nums text-stone-500">{changedCount}</span>
+              <span className="text-[10px] text-stone-400">変更</span>
+            </div>
+            <IconButton onClick={onNextChanged} label="次の変更ノード">
               <svg
-                width="12"
-                height="12"
-                viewBox="0 0 12 12"
+                width="10"
+                height="10"
+                viewBox="0 0 10 10"
                 fill="none"
                 stroke="currentColor"
-                strokeWidth="2"
+                strokeWidth="1.5"
                 strokeLinecap="round"
                 strokeLinejoin="round"
                 aria-hidden="true"
               >
-                <path d="M4.5 2.5L8 6l-3.5 3.5" />
+                <path d="M3.5 1.5L7 5l-3.5 3.5" />
               </svg>
-            </Button>
+            </IconButton>
           </div>
-        )}
-      </CardContent>
-    </Card>
+        </>
+      )}
+    </div>
   )
 }

--- a/frontend/src/components/landing/ClusterShowcase.tsx
+++ b/frontend/src/components/landing/ClusterShowcase.tsx
@@ -1,47 +1,35 @@
 import Wrap from './Wrap'
 import SectionHead from './SectionHead'
 
-type Cluster = {
+type Mode = {
   label: string
   desc: string
   icon: string
-  n: number
-  bar: string
   iconBox: string
+  badge: string
 }
 
-const CLUSTERS: Cluster[] = [
+const MODES: Mode[] = [
   {
-    label: '追加',
-    desc: '新規モジュール',
-    icon: '+',
-    n: 11,
-    bar: 'bg-green-600',
-    iconBox: 'bg-green-100 border-green-300 text-green-600',
+    label: 'Louvain',
+    desc: '依存関係の密度からコミュニティを自動検出',
+    icon: '{}',
+    iconBox: 'bg-teal-100 border-teal-300 text-teal-700',
+    badge: '既定',
   },
   {
-    label: '削除',
-    desc: '削除されたモジュール',
-    icon: '−',
-    n: 4,
-    bar: 'bg-red-600',
-    iconBox: 'bg-red-100 border-red-300 text-red-600',
-  },
-  {
-    label: '修正',
-    desc: 'ロジック変更を含む',
-    icon: '~',
-    n: 13,
-    bar: 'bg-amber-600',
-    iconBox: 'bg-amber-100 border-amber-300 text-amber-600',
-  },
-  {
-    label: 'リファクタ',
-    desc: '振る舞い保存・構造変更',
-    icon: '↻',
-    n: 6,
-    bar: 'bg-violet-600',
+    label: 'パッケージ',
+    desc: 'Go パッケージ単位でグルーピング',
+    icon: '/',
     iconBox: 'bg-violet-100 border-violet-300 text-violet-600',
+    badge: '',
+  },
+  {
+    label: 'ファイル',
+    desc: 'ソースファイル単位でグルーピング',
+    icon: '[ ]',
+    iconBox: 'bg-amber-100 border-amber-300 text-amber-600',
+    badge: '',
   },
 ]
 
@@ -53,29 +41,32 @@ export default function ClusterShowcase() {
     >
       <Wrap>
         <SectionHead
-          eyebrow="4-way auto cluster"
-          title="変更の種類で、自動的に4つに分ける。"
-          lead="ファイル名やパスではなく、AST と呼び出しグラフから「変更の意味」を抽出。レビュアーは色とまとまりで読み進められます。"
+          eyebrow="Smart clustering"
+          title="依存関係から、自動でクラスタを生成。"
+          lead="Louvain アルゴリズムが呼び出しグラフのコミュニティ構造を検出し、関連する関数群を意味のあるまとまりに自動分割。パッケージ・ファイル単位への切替もワンクリック。"
         />
-        <div className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          {CLUSTERS.map((k) => (
+        <div className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {MODES.map((m) => (
             <div
-              key={k.label}
+              key={m.label}
               className="relative overflow-hidden rounded-[14px] border border-stone-200 bg-white p-[22px]"
             >
-              <div className={`absolute inset-y-0 left-0 w-[3px] ${k.bar}`} />
               <div className="flex items-center justify-between">
                 <div
-                  className={`flex size-[38px] items-center justify-center rounded-[10px] border text-lg font-semibold ${k.iconBox}`}
+                  className={`flex size-[38px] items-center justify-center rounded-[10px] border font-mono text-sm font-semibold ${m.iconBox}`}
                 >
-                  {k.icon}
+                  {m.icon}
                 </div>
-                <div className="font-mono text-[11px] text-stone-500">n={k.n}</div>
+                {m.badge && (
+                  <span className="rounded-full bg-teal-100 px-2 py-0.5 text-[10px] font-medium text-teal-700">
+                    {m.badge}
+                  </span>
+                )}
               </div>
               <div className="mt-4 text-base font-semibold tracking-[-0.01em] text-stone-900">
-                {k.label}
+                {m.label}
               </div>
-              <div className="mt-1 text-[13px] leading-normal text-stone-500">{k.desc}</div>
+              <div className="mt-1 text-[13px] leading-normal text-stone-500">{m.desc}</div>
             </div>
           ))}
         </div>

--- a/frontend/src/components/landing/CtaStrip.tsx
+++ b/frontend/src/components/landing/CtaStrip.tsx
@@ -21,7 +21,7 @@ export default function CtaStrip({ isAuthenticated }: { isAuthenticated: boolean
             <span className="text-teal-300">構造を読もう。</span>
           </h2>
           <p className="m-0 mb-8 max-w-[480px] text-base leading-relaxed text-white/65">
-            GitHub と連携して 30 秒で開始。公開リポジトリは無料、Pro プラン招待ベータ受付中。
+            GitHub と連携するだけですぐに使えます。パブリックリポジトリは無料で解析可能。
           </p>
           {isAuthenticated ? (
             <Button

--- a/frontend/src/components/landing/FeatureGrid.tsx
+++ b/frontend/src/components/landing/FeatureGrid.tsx
@@ -81,24 +81,69 @@ function FeatureArt2() {
 function FeatureArt3() {
   return (
     <svg viewBox="0 0 200 120" className="h-full w-full" aria-hidden="true">
-      <rect x="20" y="20" width="100" height="80" rx="8" fill="white" stroke="#d6d3d1" />
-      <text x="30" y="38" fontSize="9" fill="#78716c" fontFamily="JetBrains Mono">
-        func Charge()
-      </text>
-      <rect x="30" y="46" width="80" height="2" fill="#78716c" opacity="0.2" />
-      <rect x="30" y="52" width="60" height="2" fill="#78716c" opacity="0.2" />
-      <rect x="30" y="58" width="70" height="2" fill="#78716c" opacity="0.2" />
-      <path d="M120 60 L150 40" stroke="#0f766e" strokeWidth="1.5" />
-      <g>
-        <rect x="140" y="20" width="50" height="36" rx="8" fill="#0f766e" />
-        <circle cx="151" cy="32" r="3" fill="white" />
-        <rect x="158" y="30" width="22" height="2" fill="white" opacity="0.7" />
-        <rect x="158" y="34" width="18" height="2" fill="white" opacity="0.7" />
-        <rect x="158" y="38" width="20" height="2" fill="white" opacity="0.7" />
-        <text x="146" y="50" fontSize="7" fill="white" opacity="0.8" fontFamily="JetBrains Mono">
-          @ shimo-dev
-        </text>
+      <g stroke="#d6d3d1" strokeWidth="1" fill="none">
+        <path d="M60 30 L100 60" />
+        <path d="M140 30 L100 60" />
+        <path d="M100 60 L60 90" />
+        <path d="M100 60 L140 90" />
       </g>
+      <rect x="40" y="18" width="40" height="24" rx="4" fill="white" stroke="#d6d3d1" />
+      <text
+        x="60"
+        y="34"
+        textAnchor="middle"
+        fontSize="8"
+        fill="#44403c"
+        fontFamily="JetBrains Mono"
+      >
+        funcA
+      </text>
+      <rect x="120" y="18" width="40" height="24" rx="4" fill="white" stroke="#d6d3d1" />
+      <text
+        x="140"
+        y="34"
+        textAnchor="middle"
+        fontSize="8"
+        fill="#44403c"
+        fontFamily="JetBrains Mono"
+      >
+        funcB
+      </text>
+      <circle cx="100" cy="60" r="14" fill="#ef4444" />
+      <text
+        x="100"
+        y="64"
+        textAnchor="middle"
+        fontSize="8"
+        fill="white"
+        fontFamily="JetBrains Mono"
+        fontWeight="600"
+      >
+        ↻
+      </text>
+      <rect x="40" y="78" width="40" height="24" rx="4" fill="white" stroke="#d6d3d1" />
+      <text
+        x="60"
+        y="94"
+        textAnchor="middle"
+        fontSize="8"
+        fill="#44403c"
+        fontFamily="JetBrains Mono"
+      >
+        funcC
+      </text>
+      <rect x="120" y="78" width="40" height="24" rx="4" fill="#fee2e2" stroke="#fca5a5" />
+      <text
+        x="140"
+        y="94"
+        textAnchor="middle"
+        fontSize="8"
+        fill="#dc2626"
+        fontFamily="JetBrains Mono"
+      >
+        funcD
+      </text>
+      <path d="M140 78 L100 74" stroke="#ef4444" strokeWidth="2" fill="none" />
     </svg>
   )
 }
@@ -117,8 +162,8 @@ const FEATURES: Feature[] = [
     art: <FeatureArt2 />,
   },
   {
-    title: 'コメントは AST に紐づく',
-    desc: 'rebase してもコメントが迷子にならない。ノード単位で議論を継続できます。',
+    title: '新規循環参照を自動検出',
+    desc: 'PR で新たに生じた循環依存を赤でハイライト。構造リスクをレビュー前に把握できます。',
     art: <FeatureArt3 />,
   },
 ]

--- a/frontend/src/components/landing/HowItWorks.tsx
+++ b/frontend/src/components/landing/HowItWorks.tsx
@@ -72,23 +72,65 @@ function StepMock2() {
 }
 
 function StepMock3() {
-  const bars: [string, string, string, number][] = [
-    ['追加', 'bg-green-100 border-green-300', 'bg-green-600', 70],
-    ['修正', 'bg-amber-100 border-amber-300', 'bg-amber-600', 90],
-    ['リファクタ', 'bg-violet-100 border-violet-300', 'bg-violet-600', 45],
-    ['削除', 'bg-red-100 border-red-300', 'bg-red-600', 30],
+  const nodes: { x: number; y: number; label: string; color: string }[] = [
+    { x: 20, y: 16, label: 'Cluster A', color: '#0f766e' },
+    { x: 130, y: 16, label: 'Cluster B', color: '#7c3aed' },
+    { x: 75, y: 80, label: 'Cluster C', color: '#d97706' },
   ]
   return (
-    <div className="flex w-full flex-col gap-1.5">
-      {bars.map(([lbl, track, fill, w]) => (
-        <div key={lbl} className="flex items-center gap-2">
-          <span className="w-16 text-[11px] text-stone-700">{lbl}</span>
-          <div className={`h-2.5 flex-1 overflow-hidden rounded-full border ${track}`}>
-            <div className={`h-full opacity-85 ${fill}`} style={{ width: `${w}%` }} />
-          </div>
-        </div>
+    <svg viewBox="0 0 220 140" className="w-full" aria-hidden="true">
+      <rect
+        x="14"
+        y="10"
+        width="92"
+        height="52"
+        rx="8"
+        fill="#f0fdfa"
+        stroke="#99f6e4"
+        strokeDasharray="3 2"
+      />
+      <rect
+        x="124"
+        y="10"
+        width="82"
+        height="52"
+        rx="8"
+        fill="#f5f3ff"
+        stroke="#c4b5fd"
+        strokeDasharray="3 2"
+      />
+      <rect
+        x="69"
+        y="74"
+        width="82"
+        height="52"
+        rx="8"
+        fill="#fffbeb"
+        stroke="#fcd34d"
+        strokeDasharray="3 2"
+      />
+      {nodes.map((n) => (
+        <g key={n.label}>
+          <circle cx={n.x + 20} cy={n.y + 22} r="6" fill={n.color} />
+          <circle cx={n.x + 38} cy={n.y + 18} r="4" fill={n.color} opacity="0.6" />
+          <circle cx={n.x + 52} cy={n.y + 26} r="5" fill={n.color} opacity="0.8" />
+          <text
+            x={n.x + 36}
+            y={n.y + 44}
+            textAnchor="middle"
+            fontSize="8"
+            fill="#78716c"
+            fontFamily="Inter Tight"
+          >
+            {n.label}
+          </text>
+        </g>
       ))}
-    </div>
+      <g stroke="#d6d3d1" strokeWidth="1" fill="none">
+        <path d="M60 50 Q80 68 90 80" />
+        <path d="M150 58 Q140 68 130 80" />
+      </g>
+    </svg>
   )
 }
 
@@ -109,8 +151,8 @@ const STEPS: Step[] = [
   },
   {
     n: '03',
-    title: 'クラスタごとに読む',
-    desc: '追加 → 修正 → リファクタ → 削除 の順に、レビュアーの認知に沿った読み方を提案します。',
+    title: 'クラスタで構造を把握',
+    desc: 'Louvain アルゴリズムが関連する関数群をクラスタに自動分割。変更ノードを優先度順にナビゲートして効率的にレビュー。',
     mock: <StepMock3 />,
   },
 ]

--- a/frontend/src/components/landing/LandingFooter.tsx
+++ b/frontend/src/components/landing/LandingFooter.tsx
@@ -13,27 +13,13 @@ const COLS: Col[] = [
     links: [
       { label: '機能', href: '#features' },
       { label: '仕組み', href: '#how' },
-      { label: '料金' },
-      { label: 'ロードマップ' },
-      { label: '変更履歴' },
     ],
   },
   {
-    title: 'ドキュメント',
+    title: 'リソース',
     links: [
-      { label: 'はじめに' },
-      { label: 'API リファレンス' },
-      { label: 'セルフホスト' },
-      { label: 'CLI' },
-    ],
-  },
-  {
-    title: '会社',
-    links: [
-      { label: 'About' },
-      { label: 'ブログ' },
-      { label: 'お問い合わせ' },
-      { label: 'プレスキット' },
+      { label: 'GitHub', href: REPO_URL },
+      { label: 'README', href: `${REPO_URL}#readme` },
     ],
   },
 ]
@@ -41,7 +27,11 @@ const COLS: Col[] = [
 function FooterLink({ link }: { link: Link }) {
   if (link.href) {
     return (
-      <a href={link.href} className="text-[13px] text-stone-500 hover:text-stone-700">
+      <a
+        href={link.href}
+        className="text-[13px] text-stone-500 hover:text-stone-700"
+        {...(link.href.startsWith('http') ? { target: '_blank', rel: 'noreferrer' } : {})}
+      >
         {link.label}
       </a>
     )
@@ -52,7 +42,7 @@ function FooterLink({ link }: { link: Link }) {
 export default function LandingFooter() {
   return (
     <footer className="border-t border-stone-200 bg-white pt-18 pb-10">
-      <Wrap className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-[1.4fr_repeat(3,1fr)] lg:gap-12">
+      <Wrap className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-[1.6fr_repeat(2,1fr)] lg:gap-12">
         <div>
           <Brand size={16} />
           <p className="my-3.5 mb-5 max-w-[280px] text-[13px] leading-relaxed text-stone-500">

--- a/frontend/src/components/landing/LandingHero.tsx
+++ b/frontend/src/components/landing/LandingHero.tsx
@@ -3,19 +3,6 @@ import GuestCta from './GuestCta'
 import PrInputForm from './PrInputForm'
 import HeroIllustration from './HeroIllustration'
 
-function Stat({ n, l }: { n: string; l: string }) {
-  return (
-    <div>
-      <div className="text-[22px] font-semibold tracking-[-0.02em] text-stone-900 tabular-nums">
-        {n}
-      </div>
-      <div className="mt-0.5 text-xs text-stone-500">{l}</div>
-    </div>
-  )
-}
-
-const Divider = () => <div className="h-8 w-px bg-stone-200" />
-
 export default function LandingHero({ isAuthenticated }: { isAuthenticated: boolean }) {
   return (
     <section className="relative overflow-hidden border-b border-stone-200">
@@ -41,19 +28,11 @@ export default function LandingHero({ isAuthenticated }: { isAuthenticated: bool
             <span className="text-teal-700">構造</span>として読む。
           </h1>
           <p className="m-0 mb-8 max-w-[500px] text-[17px] leading-relaxed text-stone-700">
-            変更ファイルの羅列ではなく、モジュールの依存関係として PR を可視化。100
-            ファイル超のレビューも、4 つの意味のあるクラスタに自動分割します。
+            変更ファイルの羅列ではなく、モジュールの依存関係として PR
+            を可視化。大規模レビューも、意味のあるクラスタに自動分割します。
           </p>
 
           {isAuthenticated ? <PrInputForm /> : <GuestCta />}
-
-          <div className="mt-10 flex flex-wrap items-center gap-7">
-            <Stat n="2,400+" l="解析された PR" />
-            <Divider />
-            <Stat n="38%" l="レビュー時間短縮" />
-            <Divider />
-            <Stat n="< 5s" l="平均解析時間" />
-          </div>
         </div>
 
         <HeroIllustration />

--- a/frontend/src/components/landing/LandingNav.tsx
+++ b/frontend/src/components/landing/LandingNav.tsx
@@ -20,6 +20,9 @@ export default function LandingNav({ isAuthenticated, login }: Props) {
           <a className={`${navLink} hidden md:inline-flex`} href="#how">
             仕組み
           </a>
+          <a className={`${navLink} hidden md:inline-flex`} href="#showcase">
+            クラスタリング
+          </a>
           <a
             className={`${navLink} hidden md:inline-flex`}
             href={REPO_URL}


### PR DESCRIPTION
## Summary
- LP（ランディングページ）の記述を実装済み機能に合わせて修正（架空の4分類・統計値・非ゴール機能・デッドリンクを削除し、実際のLouvainクラスタリング・循環参照検出等に差替え）
- GraphControls を frosted glass フローティングパネルに刷新（pill型セグメントコントロール、セクションラベル、アイコン付きボタン）
- design handoff（landing.jsx）と DESIGN.md を実装に同期

Closes #112

## Test plan
- [ ] LP: 各セクション（ClusterShowcase / FeatureGrid / HowItWorks / Hero / CTA / Footer / Nav）が正しく表示されること
- [ ] LP: 未ログイン/ログイン済みで Hero と CTA の表示が切り替わること
- [ ] LP: レスポンシブ（モバイル幅）でレイアウトが崩れないこと
- [ ] GraphControls: 表示モード切替（変更影響/全体）が動作すること
- [ ] GraphControls: クラスタモード切替（Louvain/Package/File）が動作すること
- [ ] GraphControls: 展開/折畳ボタンが動作すること
- [ ] GraphControls: 変更ノードステップナビゲーターが動作すること
- [ ] GraphControls: frosted glass 効果（背景の透過+ぼかし）が見えること
- [ ] design preview（design/preview.html）で landing.jsx の変更が反映されていること