### PR TITLE
fix: GitHub API レート制限対策を実装

### DIFF
--- a/backend/internal/infra/analyzer/diff.go
+++ b/backend/internal/infra/analyzer/diff.go
@@ -3,11 +3,14 @@ package analyzer
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"golang.org/x/sync/errgroup"
 
 	"github.com/s-sh1m0/u-22_procon/backend/internal/domain"
 )
+
+const maxDiffFiles = 100
 
 // diffCollector は CollectDiffFiles が依存する PRRepository の最小インターフェース。
 type diffCollector interface {
@@ -17,6 +20,11 @@ type diffCollector interface {
 // CollectDiffFiles は変更ファイル一覧に対して GitHub Contents API で before/after 全文を取得する。
 // 並列度は 8 に制限する。
 func CollectDiffFiles(ctx context.Context, repo diffCollector, token string, pr domain.PRInfo, changed []domain.ChangedFile) ([]domain.DiffFile, error) {
+	if len(changed) > maxDiffFiles {
+		log.Printf("analyzer: diff collection limited to %d/%d files", maxDiffFiles, len(changed))
+		changed = changed[:maxDiffFiles]
+	}
+
 	type result struct {
 		idx  int
 		file domain.DiffFile

--- a/backend/internal/infra/github/client.go
+++ b/backend/internal/infra/github/client.go
@@ -9,6 +9,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
+const maxCachedClients = 64
+
 // NewClientFactory はトークンごとにクライアントをキャッシュし、
 // レート制限対応の go-github クライアントを返す関数を生成する。
 // 同一トークンのリクエスト間でレート制限状態を共有する。
@@ -26,6 +28,10 @@ func NewClientFactory() func(ctx context.Context, accessToken string) *gogithub.
 
 		if c, ok := cache[accessToken]; ok {
 			return c
+		}
+
+		if len(cache) >= maxCachedClients {
+			clear(cache)
 		}
 
 		rlt := newRateLimitTransport(http.DefaultTransport)

--- a/backend/internal/infra/github/client.go
+++ b/backend/internal/infra/github/client.go
@@ -3,18 +3,38 @@ package github
 import (
 	"context"
 	"net/http"
+	"sync"
 
 	gogithub "github.com/google/go-github/v69/github"
 	"golang.org/x/oauth2"
 )
 
-// NewClient は accessToken でユーザー認証された go-github クライアントを返す。
-// PRRepo 内からリクエストごとに呼ばれる想定。
-func NewClient(ctx context.Context, accessToken string) *gogithub.Client {
-	var httpClient *http.Client
-	if accessToken != "" {
+// NewClientFactory はトークンごとにクライアントをキャッシュし、
+// レート制限対応の go-github クライアントを返す関数を生成する。
+// 同一トークンのリクエスト間でレート制限状態を共有する。
+func NewClientFactory() func(ctx context.Context, accessToken string) *gogithub.Client {
+	var mu sync.Mutex
+	cache := make(map[string]*gogithub.Client)
+
+	return func(_ context.Context, accessToken string) *gogithub.Client {
+		if accessToken == "" {
+			return gogithub.NewClient(nil)
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		if c, ok := cache[accessToken]; ok {
+			return c
+		}
+
+		rlt := newRateLimitTransport(http.DefaultTransport)
 		ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken})
-		httpClient = oauth2.NewClient(ctx, ts)
+		httpClient := &http.Client{
+			Transport: &oauth2.Transport{Source: ts, Base: rlt},
+		}
+		c := gogithub.NewClient(httpClient)
+		cache[accessToken] = c
+		return c
 	}
-	return gogithub.NewClient(httpClient)
 }

--- a/backend/internal/infra/github/pr.go
+++ b/backend/internal/infra/github/pr.go
@@ -22,8 +22,9 @@ type PRRepo struct {
 }
 
 // NewPRRepo は本番用の PRRepo を返す。
+// レート制限対応・クライアントキャッシュ付きの ClientFactory を使う。
 func NewPRRepo() *PRRepo {
-	return &PRRepo{newClient: NewClient}
+	return &PRRepo{newClient: NewClientFactory()}
 }
 
 // GetPR は PR のメタデータ（タイトル・base/head ref・head SHA）を取得する。

--- a/backend/internal/infra/github/ratelimit.go
+++ b/backend/internal/infra/github/ratelimit.go
@@ -1,0 +1,168 @@
+package github
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+const maxRetries = 3
+
+// rateLimitTransport は http.RoundTripper をラップし、GitHub API の
+// レート制限(429/403)と一時的なサーバーエラー(5xx)をリトライする。
+type rateLimitTransport struct {
+	base      http.RoundTripper
+	mu        sync.Mutex
+	remaining int
+	resetAt   time.Time
+}
+
+func newRateLimitTransport(base http.RoundTripper) *rateLimitTransport {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &rateLimitTransport{
+		base:      base,
+		remaining: -1,
+	}
+}
+
+// RoundTrip はリクエストを送信し、レート制限や 5xx に対してリトライする。
+func (t *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.waitIfExhausted(req)
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			if err := req.Context().Err(); err != nil {
+				return nil, err
+			}
+		}
+
+		r := req
+		if attempt > 0 {
+			r = req.Clone(req.Context())
+		}
+
+		resp, err := t.base.RoundTrip(r)
+		if err != nil {
+			return nil, err
+		}
+
+		t.updateRateLimit(resp)
+
+		if !isRetryableStatus(resp) || attempt == maxRetries {
+			return resp, nil
+		}
+
+		wait := retryWait(resp, attempt)
+		log.Printf("github: %d response, retry in %s (%d/%d)",
+			resp.StatusCode, wait, attempt+1, maxRetries)
+		_ = resp.Body.Close()
+
+		timer := time.NewTimer(wait)
+		select {
+		case <-timer.C:
+		case <-req.Context().Done():
+			timer.Stop()
+			return nil, req.Context().Err()
+		}
+	}
+	return nil, req.Context().Err()
+}
+
+func (t *rateLimitTransport) waitIfExhausted(req *http.Request) {
+	t.mu.Lock()
+	remaining := t.remaining
+	resetAt := t.resetAt
+	t.mu.Unlock()
+
+	if remaining != 0 || resetAt.IsZero() {
+		return
+	}
+
+	wait := time.Until(resetAt)
+	if wait <= 0 {
+		return
+	}
+	const maxWait = 120 * time.Second
+	if wait > maxWait {
+		wait = maxWait
+	}
+
+	log.Printf("github: rate limit exhausted, waiting %s", wait)
+	timer := time.NewTimer(wait)
+	select {
+	case <-timer.C:
+	case <-req.Context().Done():
+		timer.Stop()
+	}
+}
+
+func (t *rateLimitTransport) updateRateLimit(resp *http.Response) {
+	rem, err := strconv.Atoi(resp.Header.Get("X-RateLimit-Remaining"))
+	if err != nil {
+		return
+	}
+	resetUnix, err := strconv.ParseInt(resp.Header.Get("X-RateLimit-Reset"), 10, 64)
+	if err != nil {
+		return
+	}
+
+	t.mu.Lock()
+	t.remaining = rem
+	t.resetAt = time.Unix(resetUnix, 0)
+	t.mu.Unlock()
+}
+
+func isRetryableStatus(resp *http.Response) bool {
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return true
+	}
+	if resp.StatusCode == http.StatusForbidden && isRateLimited(resp) {
+		return true
+	}
+	return resp.StatusCode >= 500
+}
+
+func isRateLimited(resp *http.Response) bool {
+	if resp.Header.Get("X-RateLimit-Remaining") == "0" {
+		return true
+	}
+	return resp.Header.Get("Retry-After") != ""
+}
+
+func retryWait(resp *http.Response, attempt int) time.Duration {
+	const maxWait = 120 * time.Second
+
+	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusForbidden {
+		if ra := resp.Header.Get("Retry-After"); ra != "" {
+			if seconds, err := strconv.Atoi(ra); err == nil && seconds > 0 {
+				d := time.Duration(seconds) * time.Second
+				if d > maxWait {
+					return maxWait
+				}
+				return d
+			}
+		}
+		if reset := resp.Header.Get("X-RateLimit-Reset"); reset != "" {
+			if resetUnix, err := strconv.ParseInt(reset, 10, 64); err == nil {
+				wait := time.Until(time.Unix(resetUnix, 0))
+				if wait > 0 {
+					if wait > maxWait {
+						return maxWait
+					}
+					return wait
+				}
+			}
+		}
+		return 60 * time.Second
+	}
+
+	d := time.Duration(1<<uint(attempt)) * time.Second
+	if d > maxWait {
+		return maxWait
+	}
+	return d
+}

--- a/backend/internal/infra/github/ratelimit.go
+++ b/backend/internal/infra/github/ratelimit.go
@@ -172,16 +172,20 @@ func rateLimitWait(resp *http.Response, maxWait time.Duration) time.Duration {
 		}
 	}
 
-	if reset := resp.Header.Get("X-RateLimit-Reset"); reset != "" {
-		if resetUnix, err := strconv.ParseInt(reset, 10, 64); err == nil {
-			wait := time.Until(time.Unix(resetUnix, 0))
-			if wait > 0 && wait <= maxWait {
-				return wait
-			}
-			if wait > maxWait {
-				return maxWait
-			}
-		}
+	reset := resp.Header.Get("X-RateLimit-Reset")
+	if reset == "" {
+		return 60 * time.Second
+	}
+	resetUnix, err := strconv.ParseInt(reset, 10, 64)
+	if err != nil {
+		return 60 * time.Second
+	}
+	wait := time.Until(time.Unix(resetUnix, 0))
+	if wait > maxWait {
+		return maxWait
+	}
+	if wait > 0 {
+		return wait
 	}
 
 	return 60 * time.Second

--- a/backend/internal/infra/github/ratelimit.go
+++ b/backend/internal/infra/github/ratelimit.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"log"
+	"math/rand/v2"
 	"net/http"
 	"strconv"
 	"sync"
@@ -43,6 +44,13 @@ func (t *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, error
 		r := req
 		if attempt > 0 {
 			r = req.Clone(req.Context())
+			if req.GetBody != nil {
+				body, err := req.GetBody()
+				if err != nil {
+					return nil, err
+				}
+				r.Body = body
+			}
 		}
 
 		resp, err := t.base.RoundTrip(r)
@@ -53,6 +61,10 @@ func (t *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, error
 		t.updateRateLimit(resp)
 
 		if !isRetryableStatus(resp) || attempt == maxRetries {
+			return resp, nil
+		}
+
+		if req.Body != nil && req.GetBody == nil {
 			return resp, nil
 		}
 
@@ -93,10 +105,10 @@ func (t *rateLimitTransport) waitIfExhausted(req *http.Request) {
 
 	log.Printf("github: rate limit exhausted, waiting %s", wait)
 	timer := time.NewTimer(wait)
+	defer timer.Stop()
 	select {
 	case <-timer.C:
 	case <-req.Context().Done():
-		timer.Stop()
 	}
 }
 
@@ -137,32 +149,40 @@ func retryWait(resp *http.Response, attempt int) time.Duration {
 	const maxWait = 120 * time.Second
 
 	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusForbidden {
-		if ra := resp.Header.Get("Retry-After"); ra != "" {
-			if seconds, err := strconv.Atoi(ra); err == nil && seconds > 0 {
-				d := time.Duration(seconds) * time.Second
-				if d > maxWait {
-					return maxWait
-				}
-				return d
-			}
-		}
-		if reset := resp.Header.Get("X-RateLimit-Reset"); reset != "" {
-			if resetUnix, err := strconv.ParseInt(reset, 10, 64); err == nil {
-				wait := time.Until(time.Unix(resetUnix, 0))
-				if wait > 0 {
-					if wait > maxWait {
-						return maxWait
-					}
-					return wait
-				}
-			}
-		}
-		return 60 * time.Second
+		return rateLimitWait(resp, maxWait)
 	}
 
 	d := time.Duration(1<<uint(attempt)) * time.Second
+	jitter := time.Duration(rand.IntN(1000)) * time.Millisecond
+	d += jitter
 	if d > maxWait {
 		return maxWait
 	}
 	return d
+}
+
+func rateLimitWait(resp *http.Response, maxWait time.Duration) time.Duration {
+	if ra := resp.Header.Get("Retry-After"); ra != "" {
+		if seconds, err := strconv.Atoi(ra); err == nil && seconds > 0 {
+			d := time.Duration(seconds) * time.Second
+			if d > maxWait {
+				return maxWait
+			}
+			return d
+		}
+	}
+
+	if reset := resp.Header.Get("X-RateLimit-Reset"); reset != "" {
+		if resetUnix, err := strconv.ParseInt(reset, 10, 64); err == nil {
+			wait := time.Until(time.Unix(resetUnix, 0))
+			if wait > 0 && wait <= maxWait {
+				return wait
+			}
+			if wait > maxWait {
+				return maxWait
+			}
+		}
+	}
+
+	return 60 * time.Second
 }

--- a/backend/internal/infra/github/ratelimit_test.go
+++ b/backend/internal/infra/github/ratelimit_test.go
@@ -1,0 +1,230 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRateLimitTransport_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "4999")
+		w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10))
+		w.WriteHeader(200)
+	}))
+	t.Cleanup(srv.Close)
+
+	rlt := newRateLimitTransport(http.DefaultTransport)
+	req, _ := http.NewRequest("GET", srv.URL, nil)
+	resp, err := rlt.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("got %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestRateLimitTransport_Retry429(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := calls.Add(1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(429)
+			return
+		}
+		w.Header().Set("X-RateLimit-Remaining", "4998")
+		w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10))
+		w.WriteHeader(200)
+	}))
+	t.Cleanup(srv.Close)
+
+	rlt := newRateLimitTransport(http.DefaultTransport)
+	req, _ := http.NewRequest("GET", srv.URL, nil)
+	resp, err := rlt.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("got %d, want 200", resp.StatusCode)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("expected 2 calls, got %d", got)
+	}
+}
+
+func TestRateLimitTransport_Retry403RateLimit(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := calls.Add(1)
+		if n == 1 {
+			w.Header().Set("X-RateLimit-Remaining", "0")
+			w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(time.Now().Add(1*time.Second).Unix(), 10))
+			w.WriteHeader(403)
+			return
+		}
+		w.Header().Set("X-RateLimit-Remaining", "4999")
+		w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10))
+		w.WriteHeader(200)
+	}))
+	t.Cleanup(srv.Close)
+
+	rlt := newRateLimitTransport(http.DefaultTransport)
+	req, _ := http.NewRequest("GET", srv.URL, nil)
+	resp, err := rlt.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("got %d, want 200", resp.StatusCode)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("expected 2 calls, got %d", got)
+	}
+}
+
+func TestRateLimitTransport_Retry5xx(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := calls.Add(1)
+		if n == 1 {
+			w.WriteHeader(502)
+			return
+		}
+		w.WriteHeader(200)
+	}))
+	t.Cleanup(srv.Close)
+
+	rlt := newRateLimitTransport(http.DefaultTransport)
+	req, _ := http.NewRequest("GET", srv.URL, nil)
+	resp, err := rlt.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("got %d, want 200", resp.StatusCode)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("expected 2 calls, got %d", got)
+	}
+}
+
+func TestRateLimitTransport_MaxRetriesExhausted(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(429)
+	}))
+	t.Cleanup(srv.Close)
+
+	rlt := newRateLimitTransport(http.DefaultTransport)
+	req, _ := http.NewRequest("GET", srv.URL, nil)
+	resp, err := rlt.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != 429 {
+		t.Fatalf("got %d, want 429 after exhausting retries", resp.StatusCode)
+	}
+	if got := calls.Load(); int(got) != maxRetries+1 {
+		t.Errorf("expected %d calls, got %d", maxRetries+1, got)
+	}
+}
+
+func TestRateLimitTransport_ContextCanceled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(429)
+	}))
+	t.Cleanup(srv.Close)
+
+	rlt := newRateLimitTransport(http.DefaultTransport)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, "GET", srv.URL, nil)
+	_, err := rlt.RoundTrip(req)
+	if err == nil {
+		t.Fatal("expected error from canceled context")
+	}
+}
+
+func TestRateLimitTransport_403NotRateLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(403)
+	}))
+	t.Cleanup(srv.Close)
+
+	rlt := newRateLimitTransport(http.DefaultTransport)
+	req, _ := http.NewRequest("GET", srv.URL, nil)
+	resp, err := rlt.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != 403 {
+		t.Fatalf("got %d, want 403 (permission denied, no retry)", resp.StatusCode)
+	}
+}
+
+func TestRetryWait_RetryAfterHeader(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: 429,
+		Header:     http.Header{"Retry-After": {"30"}},
+	}
+	got := retryWait(resp, 0)
+	if got != 30*time.Second {
+		t.Errorf("got %s, want 30s", got)
+	}
+}
+
+func TestRetryWait_5xxExponentialBackoff(t *testing.T) {
+	tests := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{0, 1 * time.Second},
+		{1, 2 * time.Second},
+		{2, 4 * time.Second},
+	}
+	for _, tt := range tests {
+		resp := &http.Response{StatusCode: 500, Header: http.Header{}}
+		got := retryWait(resp, tt.attempt)
+		if got != tt.want {
+			t.Errorf("attempt %d: got %s, want %s", tt.attempt, got, tt.want)
+		}
+	}
+}
+
+func TestNewClientFactory_CachesClient(t *testing.T) {
+	factory := NewClientFactory()
+	c1 := factory(context.Background(), "token-a")
+	c2 := factory(context.Background(), "token-a")
+	c3 := factory(context.Background(), "token-b")
+
+	if c1 != c2 {
+		t.Error("same token should return the same client")
+	}
+	if c1 == c3 {
+		t.Error("different tokens should return different clients")
+	}
+}
+
+func TestNewClientFactory_EmptyToken(t *testing.T) {
+	factory := NewClientFactory()
+	c1 := factory(context.Background(), "")
+	c2 := factory(context.Background(), "")
+	if c1 == c2 {
+		t.Error("empty token should not be cached")
+	}
+}

--- a/backend/internal/infra/github/ratelimit_test.go
+++ b/backend/internal/infra/github/ratelimit_test.go
@@ -191,7 +191,7 @@ func TestRetryWait_RetryAfterHeader(t *testing.T) {
 func TestRetryWait_5xxExponentialBackoff(t *testing.T) {
 	tests := []struct {
 		attempt int
-		want    time.Duration
+		base    time.Duration
 	}{
 		{0, 1 * time.Second},
 		{1, 2 * time.Second},
@@ -200,8 +200,8 @@ func TestRetryWait_5xxExponentialBackoff(t *testing.T) {
 	for _, tt := range tests {
 		resp := &http.Response{StatusCode: 500, Header: http.Header{}}
 		got := retryWait(resp, tt.attempt)
-		if got != tt.want {
-			t.Errorf("attempt %d: got %s, want %s", tt.attempt, got, tt.want)
+		if got < tt.base || got > tt.base+time.Second {
+			t.Errorf("attempt %d: got %s, want [%s, %s]", tt.attempt, got, tt.base, tt.base+time.Second)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- `rateLimitTransport` を追加し、429 / 403(rate limit) / 5xx レスポンスに対してリトライ+指数バックオフを実装
- `NewClientFactory` でトークン単位にクライアントをキャッシュし、同一トークンのリクエスト間でレート制限状態（remaining/reset）を共有
- `CollectDiffFiles` に100ファイル上限を追加し、大規模 PR での過剰な Contents API 呼び出しを防止

## 対策の詳細
| # | 対策 | 実装箇所 |
|---|---|---|
| 1 | ファイル数上限 | `analyzer/diff.go` — `maxDiffFiles = 100` |
| 2 | Rate Limit ヘッダー監視 | `github/ratelimit.go` — `updateRateLimit()` |
| 3 | 429/403 ハンドリング | `github/ratelimit.go` — `isRetryableStatus()` |
| 4 | クライアント再利用 | `github/client.go` — `NewClientFactory()` |
| 5 | 指数バックオフ | `github/ratelimit.go` — `retryWait()` |

## Test plan
- [x] `go vet` / `gofmt` 通過
- [x] 既存テスト全 PASS（`go test ./...`）
- [x] 新規テスト追加（`ratelimit_test.go`）: 成功/429リトライ/403リトライ/5xxリトライ/リトライ上限/コンテキストキャンセル/非レート制限403
- [ ] 大規模 PR（100+ファイル変更）を解析して diff 収集がファイル数制限されることを確認

Closes #114